### PR TITLE
feat(sso): single sign-on for end users from your product

### DIFF
--- a/app/components/Sso/SsoIntegrationGuide.vue
+++ b/app/components/Sso/SsoIntegrationGuide.vue
@@ -1,0 +1,145 @@
+<script setup lang="ts">
+// Integration guide: endpoint + query params + JWT payload + signing snippet +
+// TTL guidance. Pure reference content for the customer's developer.
+//
+// The endpoint is derived from the CURRENT origin — i.e. whatever host is
+// serving this dashboard — so the integrator always copies a working URL.
+
+const origin = useRequestURL().origin
+const endpoint = computed(() => `${origin}/api/sso/jwt`)
+
+const queryParams = [
+  { name: 'jwt', required: true, desc: 'HS256-signed token (see payload below).' },
+  { name: 'return_to', required: false, desc: 'Where to land after sign-in. Same-host path or URL only (host-whitelisted). Defaults to /.' },
+]
+
+const payloadFields = [
+  { name: 'email', required: true, desc: 'Identity key (globally unique) + notifications.' },
+  { name: 'name', required: true, desc: 'Display name.' },
+  { name: 'picture', required: false, desc: 'Avatar URL.' },
+  { name: 'exp', required: true, desc: 'Expiry (Unix seconds). Required — see TTL below.' },
+]
+
+const snippet = computed(() => `import jwt from 'jsonwebtoken'
+
+// Pre-sign at render time (page load / widget init), NOT on click —
+// this avoids a network round-trip when the user follows the link.
+function buildFeedbackUrl(user, returnTo = '/') {
+  const token = jwt.sign(
+    {
+      email:   user.email,   // required — identity key
+      name:    user.name,    // required — display name
+      picture: user.avatar,  // optional — avatar URL
+      exp: Math.floor(Date.now() / 1000) + 60 * 60, // required — ~1h recommended
+    },
+    process.env.FEEDLOG_SSO_SECRET, // one of this workspace's enabled secrets
+    { algorithm: 'HS256' },
+  )
+
+  const base = '${endpoint.value}'
+  return \`\${base}?jwt=\${token}&return_to=\${encodeURIComponent(returnTo)}\`
+}`)
+
+const copiedKey = ref<string | null>(null)
+function copy(key: string, text: string) {
+  navigator.clipboard?.writeText(text)
+  copiedKey.value = key
+  setTimeout(() => { copiedKey.value = null }, 1500)
+}
+</script>
+
+<template>
+  <div class="space-y-6">
+    <!-- Endpoint -->
+    <section class="rounded-xl border border-border bg-card overflow-hidden">
+      <div class="px-5 py-3 border-b border-border">
+        <h3 class="font-heading font-bold text-sm">Endpoint</h3>
+        <p class="text-[11px] text-muted-foreground mt-0.5">Redirect signed-in users from your product to this URL.</p>
+      </div>
+      <div class="px-5 py-4 space-y-4">
+        <div class="flex items-center gap-2">
+          <span class="text-[10px] font-bold uppercase tracking-wider bg-secondary text-primary px-1.5 py-0.5 rounded shrink-0">GET</span>
+          <code class="flex-1 min-w-0 truncate text-xs font-mono px-2.5 py-1.5 rounded-md bg-muted border border-border">{{ endpoint }}</code>
+          <button
+            class="w-8 h-8 rounded-md hover:bg-secondary transition-colors flex items-center justify-center shrink-0"
+            :class="copiedKey === 'endpoint' ? 'text-[var(--status-done)]' : 'text-muted-foreground'"
+            @click="copy('endpoint', endpoint)"
+          >
+            <Icon :name="copiedKey === 'endpoint' ? 'lucide:check' : 'lucide:copy'" size="14" />
+          </button>
+        </div>
+
+        <!-- Query params -->
+        <div>
+          <p class="text-[11px] font-bold uppercase tracking-wider text-muted-foreground mb-2">Query parameters</p>
+          <ul class="divide-y divide-border rounded-lg border border-border overflow-hidden">
+            <li v-for="q in queryParams" :key="q.name" class="px-3 py-2.5 flex items-start gap-3 bg-background">
+              <code class="text-xs font-mono font-bold text-foreground shrink-0 w-[88px]">{{ q.name }}</code>
+              <span
+                class="text-[10px] font-bold uppercase tracking-wider px-1.5 py-0.5 rounded shrink-0"
+                :class="q.required ? 'bg-secondary text-primary' : 'bg-muted text-muted-foreground'"
+              >{{ q.required ? 'Required' : 'Optional' }}</span>
+              <span class="text-xs text-muted-foreground leading-snug">{{ q.desc }}</span>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    <!-- JWT payload -->
+    <section class="rounded-xl border border-border bg-card overflow-hidden">
+      <div class="px-5 py-3 border-b border-border">
+        <h3 class="font-heading font-bold text-sm">JWT payload</h3>
+        <p class="text-[11px] text-muted-foreground mt-0.5">The signed-in user's info, carried in the token. FeedLog reads only these fields — any other claims are ignored.</p>
+      </div>
+      <ul class="divide-y divide-border">
+        <li v-for="f in payloadFields" :key="f.name" class="px-5 py-2.5 flex items-start gap-3">
+          <code class="text-xs font-mono font-bold text-foreground shrink-0 w-[110px]">{{ f.name }}</code>
+          <span
+            class="text-[10px] font-bold uppercase tracking-wider px-1.5 py-0.5 rounded shrink-0"
+            :class="f.required ? 'bg-secondary text-primary' : 'bg-muted text-muted-foreground'"
+          >{{ f.required ? 'Required' : 'Optional' }}</span>
+          <span class="text-xs text-muted-foreground leading-snug">{{ f.desc }}</span>
+        </li>
+      </ul>
+    </section>
+
+    <!-- Signing example -->
+    <section class="rounded-xl border border-border bg-card overflow-hidden">
+      <div class="px-5 py-3 border-b border-border flex items-center justify-between">
+        <div>
+          <h3 class="font-heading font-bold text-sm">Sign &amp; redirect (Node.js)</h3>
+          <p class="text-[11px] text-muted-foreground mt-0.5">Build the link on your backend.</p>
+        </div>
+        <button
+          class="h-8 px-2.5 rounded-md border border-border bg-background hover:bg-secondary transition-colors flex items-center gap-1.5 text-xs font-semibold"
+          :class="copiedKey === 'snippet' ? 'text-[var(--status-done)]' : 'text-muted-foreground'"
+          @click="copy('snippet', snippet)"
+        >
+          <Icon :name="copiedKey === 'snippet' ? 'lucide:check' : 'lucide:copy'" size="13" />
+          {{ copiedKey === 'snippet' ? 'Copied' : 'Copy' }}
+        </button>
+      </div>
+      <pre class="px-5 py-4 overflow-x-auto text-xs font-mono leading-relaxed text-foreground bg-muted/40"><code>{{ snippet }}</code></pre>
+    </section>
+
+    <!-- TTL guidance -->
+    <div class="flex items-start gap-2.5 p-4 rounded-xl bg-amber-50 border border-amber-200 text-amber-900">
+      <Icon name="lucide:clock" size="15" class="mt-0.5 shrink-0 text-amber-600" />
+      <div class="text-xs leading-relaxed">
+        <p class="font-bold">Token expiry (<code class="font-mono">exp</code>) is required</p>
+        <p class="mt-1">
+          Recommended ~1 hour; hard cap 24 hours (±60s clock tolerance). Pre-sign tokens when you render the page —
+          not when the user clicks — to avoid an extra round-trip.
+        </p>
+      </div>
+    </div>
+
+    <!-- How it works footnote -->
+    <p class="text-[11px] text-muted-foreground leading-relaxed">
+      <Icon name="lucide:info" size="11" class="inline mr-1" />
+      Users are matched by <span class="font-semibold">email</span>. A first-time email creates an end-user account (no
+      extra login screen); changing a user's email creates a new account and does not migrate history.
+    </p>
+  </div>
+</template>

--- a/app/components/Sso/SsoSecretDialog.vue
+++ b/app/components/Sso/SsoSecretDialog.vue
@@ -1,0 +1,82 @@
+<script setup lang="ts">
+// Create / rename dialog for an SSO signing secret. One surface for both modes
+// — the body is identical (a single optional label), only the copy differs.
+// Create: backend generates the secret. Rename: only the label changes; the
+// key is untouched.
+
+const props = defineProps<{
+  mode: 'create' | 'rename'
+  initialLabel?: string
+}>()
+
+const open = defineModel<boolean>('open', { required: true })
+
+const emit = defineEmits<{
+  submit: [payload: { label: string }]
+}>()
+
+const label = ref('')
+const labelInput = ref<HTMLInputElement | null>(null)
+
+watch(open, (v) => {
+  if (v) {
+    label.value = props.initialLabel ?? ''
+    nextTick(() => labelInput.value?.focus())
+  }
+})
+
+const copy = computed(() => props.mode === 'rename'
+  ? {
+      title: 'Rename secret',
+      desc: 'Update the label used to tell this secret apart. The key itself is unchanged.',
+      action: 'Save',
+      icon: 'lucide:pencil',
+    }
+  : {
+      title: 'Create signing secret',
+      desc: 'A new HS256 secret your backend uses to sign SSO tokens. You can reveal and copy it again any time.',
+      action: 'Create secret',
+      icon: 'lucide:plus',
+    })
+
+function submit() {
+  emit('submit', { label: label.value.trim() })
+}
+</script>
+
+<template>
+  <Dialog v-model:open="open">
+    <DialogContent class="sm:max-w-md">
+      <DialogHeader>
+        <DialogTitle class="font-heading">{{ copy.title }}</DialogTitle>
+        <DialogDescription class="text-sm">{{ copy.desc }}</DialogDescription>
+      </DialogHeader>
+
+      <div>
+        <label class="text-[11px] font-bold uppercase tracking-wider text-muted-foreground">Label <span class="font-normal normal-case">(optional)</span></label>
+        <input
+          ref="labelInput"
+          v-model="label"
+          type="text"
+          placeholder="e.g. Production, EU region, mobile app"
+          class="mt-2 w-full h-10 px-3 rounded-lg border border-border bg-background text-sm focus:outline-none focus:border-primary transition-colors"
+          @keydown.enter="submit"
+        >
+        <p class="text-[11px] text-muted-foreground mt-1.5">Helps you tell multiple secrets apart when rotating.</p>
+      </div>
+
+      <DialogFooter>
+        <button class="h-9 px-4 rounded-lg border border-border bg-background text-xs font-semibold hover:bg-secondary transition-colors" @click="open = false">
+          Cancel
+        </button>
+        <button
+          class="h-9 px-4 rounded-lg bg-primary text-primary-foreground text-xs font-heading font-bold hover:opacity-90 transition-all flex items-center gap-1.5"
+          @click="submit"
+        >
+          <Icon :name="copy.icon" size="14" />
+          {{ copy.action }}
+        </button>
+      </DialogFooter>
+    </DialogContent>
+  </Dialog>
+</template>

--- a/app/components/Sso/SsoSecretRow.vue
+++ b/app/components/Sso/SsoSecretRow.vue
@@ -1,0 +1,121 @@
+<script setup lang="ts">
+import type { SsoSecret } from '~/composables/useSsoSecrets'
+
+// One signing-secret row: reveal / copy / enable-disable / rename / delete.
+// Secrets are encrypted-recoverable, so reveal is a plain toggle (not a
+// one-time show). Rename and delete are both driven by the parent via a dialog
+// (rename) / AlertDialog (delete) — this row only emits the intent.
+
+const props = defineProps<{
+  secret: SsoSecret
+  justCreated?: boolean
+}>()
+
+const emit = defineEmits<{
+  toggle: []
+  rename: []
+  delete: []
+}>()
+
+const revealed = ref(props.justCreated ?? false)
+const copied = ref(false)
+
+const displayLabel = computed(() => props.secret.label || 'Untitled')
+
+const masked = computed(() => {
+  const s = props.secret.secret
+  return `${'•'.repeat(24)}${s.slice(-4)}`
+})
+
+function copy() {
+  navigator.clipboard?.writeText(props.secret.secret)
+  copied.value = true
+  setTimeout(() => { copied.value = false }, 1500)
+}
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
+}
+</script>
+
+<template>
+  <div
+    class="px-5 py-4 transition-colors"
+    :class="secret.enabled ? '' : 'bg-muted/30'"
+  >
+    <div class="flex items-center gap-3">
+      <!-- Label + meta -->
+      <div class="min-w-0 w-[180px]">
+        <div class="flex items-center gap-1.5">
+          <p class="text-sm font-bold truncate" :class="secret.enabled ? '' : 'text-muted-foreground'">
+            {{ displayLabel }}
+          </p>
+          <span v-if="justCreated" class="text-[10px] font-bold uppercase tracking-wider text-primary bg-secondary px-1.5 py-0.5 rounded">New</span>
+        </div>
+        <p class="text-[11px] text-muted-foreground mt-0.5">Created {{ formatDate(secret.createdAt) }}</p>
+      </div>
+
+      <!-- Secret value: masked / revealed + reveal + copy -->
+      <div class="flex-1 min-w-0 flex items-center gap-1.5">
+        <code
+          class="flex-1 min-w-0 truncate text-xs font-mono px-2.5 py-1.5 rounded-md bg-muted border border-border"
+          :class="secret.enabled ? 'text-foreground' : 'text-muted-foreground'"
+        >{{ revealed ? secret.secret : masked }}</code>
+        <button
+          class="w-8 h-8 rounded-md hover:bg-secondary transition-colors flex items-center justify-center text-muted-foreground shrink-0"
+          :title="revealed ? 'Hide' : 'Reveal'"
+          @click="revealed = !revealed"
+        >
+          <Icon :name="revealed ? 'lucide:eye-off' : 'lucide:eye'" size="14" />
+        </button>
+        <button
+          class="w-8 h-8 rounded-md hover:bg-secondary transition-colors flex items-center justify-center shrink-0"
+          :class="copied ? 'text-[var(--status-done)]' : 'text-muted-foreground'"
+          :title="copied ? 'Copied' : 'Copy'"
+          @click="copy"
+        >
+          <Icon :name="copied ? 'lucide:check' : 'lucide:copy'" size="14" />
+        </button>
+      </div>
+
+      <!-- Status indicator (enable / disable action lives in the ⋯ menu) -->
+      <span
+        class="inline-flex items-center justify-center gap-1.5 h-6 rounded-full text-[11px] font-semibold shrink-0"
+        :class="secret.enabled ? '' : 'bg-muted text-muted-foreground'"
+        :style="secret.enabled
+          ? 'min-width: 82px; background-color: var(--status-done-bg); color: var(--status-done)'
+          : 'min-width: 82px'"
+      >
+        <span
+          class="w-1.5 h-1.5 rounded-full"
+          :style="{ backgroundColor: secret.enabled ? 'var(--status-done)' : 'var(--status-open)' }"
+        />
+        {{ secret.enabled ? 'Active' : 'Disabled' }}
+      </span>
+
+      <!-- More menu -->
+      <DropdownMenu>
+        <DropdownMenuTrigger as-child>
+          <button class="w-8 h-8 rounded-md hover:bg-secondary transition-colors flex items-center justify-center text-muted-foreground shrink-0">
+            <Icon name="lucide:more-horizontal" size="14" />
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" class="w-[180px]">
+          <DropdownMenuItem @click="emit('rename')">
+            <Icon name="lucide:pencil" size="13" class="mr-2" />
+            Rename
+          </DropdownMenuItem>
+          <DropdownMenuItem @click="emit('toggle')">
+            <Icon :name="secret.enabled ? 'lucide:pause' : 'lucide:play'" size="13" class="mr-2" />
+            {{ secret.enabled ? 'Disable' : 'Enable' }}
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem class="text-red-600" @click="emit('delete')">
+            <Icon name="lucide:trash-2" size="13" class="mr-2" />
+            Delete
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  </div>
+</template>

--- a/app/composables/useDashboardNav.ts
+++ b/app/composables/useDashboardNav.ts
@@ -7,6 +7,9 @@ export interface DashboardNavItem {
 export interface DashboardNav {
   mainNav: DashboardNavItem[]
   settingsNav: DashboardNavItem[]
+  // Advanced / integration surfaces. Rendered as a separate, collapsed-by-default
+  // section so it doesn't crowd the everyday Settings items.
+  developerNav: DashboardNavItem[]
 }
 
 export function useDashboardNav(): DashboardNav {
@@ -20,6 +23,9 @@ export function useDashboardNav(): DashboardNav {
       { label: 'Board',     to: '/dashboard/boards',              icon: 'lucide:settings-2' },
       { label: 'Members',   to: '/dashboard/settings/members',    icon: 'lucide:users' },
       { label: 'Workspace', to: '/dashboard/settings/workspace',  icon: 'lucide:building-2' },
+    ],
+    developerNav: [
+      { label: 'Single Sign-On', to: '/dashboard/developer/sso', icon: 'lucide:key-round' },
     ],
   }
 }

--- a/app/composables/useSsoSecrets.ts
+++ b/app/composables/useSsoSecrets.ts
@@ -1,0 +1,56 @@
+// Client-side CRUD for product-SSO signing secrets, backed by
+// /api/developer/sso/secrets (owner-only). Secrets come back in full
+// (plaintext, recoverable) so the list can re-reveal them.
+
+export interface SsoSecret {
+  id: string
+  label: string | null
+  secret: string
+  enabled: boolean
+  createdAt: string
+}
+
+export function useSsoSecrets() {
+  const secrets = ref<SsoSecret[]>([])
+  const loading = ref(true)
+  const error = ref<string | null>(null)
+
+  async function refresh() {
+    loading.value = true
+    error.value = null
+    try {
+      secrets.value = await $fetch<SsoSecret[]>('/api/developer/sso/secrets')
+    }
+    catch (e) {
+      error.value = (e as { statusMessage?: string })?.statusMessage ?? 'Failed to load secrets'
+    }
+    finally {
+      loading.value = false
+    }
+  }
+
+  async function create(label: string): Promise<SsoSecret> {
+    const created = await $fetch<SsoSecret>('/api/developer/sso/secrets', {
+      method: 'POST',
+      body: { label },
+    })
+    secrets.value = [created, ...secrets.value]
+    return created
+  }
+
+  async function update(id: string, patch: { enabled?: boolean, label?: string }): Promise<void> {
+    const updated = await $fetch<SsoSecret>(`/api/developer/sso/secrets/${id}`, {
+      method: 'PATCH',
+      body: patch,
+    })
+    const i = secrets.value.findIndex(s => s.id === id)
+    if (i >= 0) secrets.value[i] = updated
+  }
+
+  async function remove(id: string): Promise<void> {
+    await $fetch(`/api/developer/sso/secrets/${id}`, { method: 'DELETE' })
+    secrets.value = secrets.value.filter(s => s.id !== id)
+  }
+
+  return { secrets, loading, error, refresh, create, update, remove }
+}

--- a/app/layouts/dashboard.vue
+++ b/app/layouts/dashboard.vue
@@ -20,12 +20,16 @@ async function handleSignOut() {
   navigateTo('/')
 }
 
-const { mainNav, settingsNav } = useDashboardNav()
+const { mainNav, settingsNav, developerNav } = useDashboardNav()
 
 // Mobile menu
 const mobileMenuOpen = ref(false)
 const route = useRoute()
 watch(() => route.path, () => { mobileMenuOpen.value = false })
+
+// Developer section: collapsed by default, but auto-expanded when the current
+// route lives inside it (so the active page stays visible).
+const developerOpen = ref(developerNav.some(item => route.path.startsWith(item.to)))
 </script>
 
 <template>
@@ -82,6 +86,31 @@ watch(() => route.path, () => { mobileMenuOpen.value = false })
             <div class="space-y-1">
               <NuxtLink
                 v-for="item in settingsNav"
+                :key="item.to"
+                :to="item.to"
+                class="flex items-center gap-3 px-3 py-2 rounded-lg text-muted-foreground hover:bg-background hover:text-foreground transition-colors font-semibold"
+                active-class="!bg-secondary !text-primary !font-bold"
+              >
+                <Icon :name="item.icon" size="20" />
+                <span class="text-sm">{{ item.label }}</span>
+              </NuxtLink>
+            </div>
+          </div>
+          <div v-if="developerNav.length">
+            <button
+              class="w-full flex items-center justify-between px-3 mb-2 group"
+              @click="developerOpen = !developerOpen"
+            >
+              <span class="text-[11px] font-bold uppercase tracking-wider text-muted-foreground group-hover:text-foreground transition-colors">Developer</span>
+              <Icon
+                :name="developerOpen ? 'lucide:chevron-down' : 'lucide:chevron-right'"
+                size="14"
+                class="text-muted-foreground"
+              />
+            </button>
+            <div v-show="developerOpen" class="space-y-1">
+              <NuxtLink
+                v-for="item in developerNav"
                 :key="item.to"
                 :to="item.to"
                 class="flex items-center gap-3 px-3 py-2 rounded-lg text-muted-foreground hover:bg-background hover:text-foreground transition-colors font-semibold"
@@ -170,6 +199,33 @@ watch(() => route.path, () => { mobileMenuOpen.value = false })
           <div class="space-y-1">
             <NuxtLink
               v-for="item in settingsNav"
+              :key="item.to"
+              :to="item.to"
+              class="flex items-center gap-3 px-3 py-2 rounded-lg text-muted-foreground hover:bg-background hover:text-foreground transition-colors font-semibold"
+              active-class="!bg-secondary !text-primary !font-bold"
+            >
+              <Icon :name="item.icon" size="20" />
+              <span class="text-sm">{{ item.label }}</span>
+            </NuxtLink>
+          </div>
+        </div>
+
+        <!-- Developer (collapsible, collapsed by default) -->
+        <div v-if="developerNav.length">
+          <button
+            class="w-full flex items-center justify-between px-3 mb-2 group"
+            @click="developerOpen = !developerOpen"
+          >
+            <span class="text-[11px] font-bold uppercase tracking-wider text-muted-foreground group-hover:text-foreground transition-colors">Developer</span>
+            <Icon
+              :name="developerOpen ? 'lucide:chevron-down' : 'lucide:chevron-right'"
+              size="14"
+              class="text-muted-foreground"
+            />
+          </button>
+          <div v-show="developerOpen" class="space-y-1">
+            <NuxtLink
+              v-for="item in developerNav"
               :key="item.to"
               :to="item.to"
               class="flex items-center gap-3 px-3 py-2 rounded-lg text-muted-foreground hover:bg-background hover:text-foreground transition-colors font-semibold"

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -3,13 +3,20 @@ const { signOut } = useAuth()
 const { data: session } = await useAuthSession()
 
 const user = computed(() => session.value?.user)
+// SSO sessions (signed in via the customer's product) are end-user only.
+const isSsoSession = computed(
+  () => !!(session.value as { session?: { ssoOrgId?: string | null } } | null)?.session?.ssoOrgId,
+)
 // Dashboard entry visibility matches the /dashboard middleware: any org
 // member (owner / manager / contributor) gets in. Do NOT gate on
 // `user.role === 'admin'` — that's the legacy better-auth admin plugin
 // field, no longer consulted now that access is driven by org-membership
 // role.
 const orgCtx = useOrgContext()
-const canEnterDashboard = computed(() => !!user.value && !!orgCtx.value.role)
+// An SSO session is end-user only and can never reach the dashboard (server
+// gates 403, /dashboard middleware redirects). Hide the entry too so we don't
+// dangle a link that dead-ends — even if this email is an org member.
+const canEnterDashboard = computed(() => !!user.value && !!orgCtx.value.role && !isSsoSession.value)
 
 // User initials as avatar fallback
 const initials = computed(() => {
@@ -23,6 +30,9 @@ watch(user, () => { avatarError.value = false })
 
 const { isOpen: showLoginModal } = useLoginModal()
 const showChangePassword = ref(false)
+
+// SSO sessions can't manage credentials — the backend blocks set/change-password
+// etc. Hide the control instead of offering an action that 403s.
 
 const navItems = [
   { label: 'Feedback', to: '/', icon: 'lucide:message-square' },
@@ -118,7 +128,7 @@ watch(() => route.path, () => { mobileNavOpen.value = false })
                 </div>
               </DropdownMenuLabel>
               <DropdownMenuSeparator />
-              <DropdownMenuItem @click="showChangePassword = true">
+              <DropdownMenuItem v-if="!isSsoSession" @click="showChangePassword = true">
                 <Icon name="lucide:key-round" size="16" class="mr-2" />
                 Change Password
               </DropdownMenuItem>

--- a/app/middleware/admin.ts
+++ b/app/middleware/admin.ts
@@ -7,6 +7,14 @@ export default defineNuxtRouteMiddleware(async () => {
     return navigateTo('/')
   }
 
+  // SSO sessions are end-user only — never staff, even if this email is an org
+  // member. Server gates 403 regardless; bounce here too so the
+  // dashboard never half-renders before the API calls fail.
+  const ssoOrgId = (data.value as { session?: { ssoOrgId?: string | null } }).session?.ssoOrgId
+  if (ssoOrgId) {
+    return navigateTo('/')
+  }
+
   const orgList = (data.value as { orgList?: { role: string }[] }).orgList
   if (!orgList || orgList.length === 0) {
     return navigateTo('/')

--- a/app/pages/dashboard/developer/sso.vue
+++ b/app/pages/dashboard/developer/sso.vue
@@ -1,0 +1,229 @@
+<script setup lang="ts">
+import { toast } from 'vue-sonner'
+import type { SsoSecret } from '~/composables/useSsoSecrets'
+import { SSO_SECRET_LIMIT } from '~~/shared/constants/sso'
+
+// /dashboard/settings/sso — manage product-SSO signing secrets + integration
+// guide. Owner-only (the API enforces it too); other staff see a notice.
+
+definePageMeta({ layout: 'dashboard', middleware: ['admin'] })
+
+const ctx = useOrgContext()
+const isOwner = computed(() => ctx.value.role === 'owner')
+
+const { secrets, loading, refresh, create, update, remove } = useSsoSecrets()
+
+const view = ref<'secrets' | 'guide'>('secrets')
+const used = computed(() => secrets.value.length)
+const canCreate = computed(() => used.value < SSO_SECRET_LIMIT)
+
+// Defer to onMounted: the list endpoint needs the session cookie, simplest to
+// fetch client-side after mount (mirrors the Members page).
+onMounted(() => { if (isOwner.value) void refresh() })
+
+// Create + rename share one dialog (SsoSecretDialog). dialogMode picks the copy;
+// renameTarget is set only in rename mode.
+const dialogOpen = ref(false)
+const dialogMode = ref<'create' | 'rename'>('create')
+const renameTarget = ref<SsoSecret | null>(null)
+const justCreatedId = ref<string | null>(null)
+
+function openCreate() {
+  dialogMode.value = 'create'
+  renameTarget.value = null
+  dialogOpen.value = true
+}
+function openRename(s: SsoSecret) {
+  dialogMode.value = 'rename'
+  renameTarget.value = s
+  dialogOpen.value = true
+}
+
+async function onDialogSubmit(payload: { label: string }) {
+  const mode = dialogMode.value
+  const target = renameTarget.value
+  dialogOpen.value = false
+  try {
+    if (mode === 'create') {
+      const s = await create(payload.label)
+      justCreatedId.value = s.id
+      setTimeout(() => { if (justCreatedId.value === s.id) justCreatedId.value = null }, 6000)
+    }
+    else if (target) {
+      await update(target.id, { label: payload.label })
+    }
+  }
+  catch (e) {
+    toast.error((e as { statusMessage?: string })?.statusMessage
+      ?? (mode === 'create' ? 'Failed to create secret' : 'Failed to rename secret'))
+  }
+}
+
+async function onToggle(s: SsoSecret) {
+  try {
+    await update(s.id, { enabled: !s.enabled })
+  }
+  catch {
+    toast.error('Failed to update secret')
+  }
+}
+
+// Delete (page-level confirm). Keep the target in its own ref, separate from the
+// dialog's open flag — reka-ui's AlertDialogAction closes the dialog on click,
+// and if open-state and target shared one ref the close would wipe the target
+// before confirmDelete reads it (DELETE then silently never fires).
+const deleteTarget = ref<SsoSecret | null>(null)
+const showDelete = ref(false)
+function askDelete(s: SsoSecret) {
+  deleteTarget.value = s
+  showDelete.value = true
+}
+async function confirmDelete() {
+  const target = deleteTarget.value
+  showDelete.value = false
+  if (!target) return
+  try {
+    await remove(target.id)
+  }
+  catch {
+    toast.error('Failed to delete secret')
+  }
+}
+</script>
+
+<template>
+  <div class="flex flex-col h-full">
+    <!-- Header -->
+    <header class="h-16 px-6 border-b border-border flex items-center justify-between shrink-0 bg-card">
+      <div>
+        <h2 class="font-heading text-lg font-bold">Single Sign-On</h2>
+        <p class="text-xs text-muted-foreground">Let users from your product sign in without a second login</p>
+      </div>
+      <button
+        v-if="isOwner && view === 'secrets'"
+        :disabled="!canCreate"
+        class="h-9 px-4 rounded-lg bg-primary text-primary-foreground text-xs font-heading font-bold hover:opacity-90 disabled:opacity-40 disabled:cursor-not-allowed transition-all flex items-center gap-2"
+        :title="canCreate ? '' : `Limit of ${SSO_SECRET_LIMIT} secrets reached`"
+        @click="openCreate"
+      >
+        <Icon name="lucide:plus" size="14" />
+        Create secret
+      </button>
+    </header>
+
+    <!-- Sub-nav (segmented) -->
+    <div class="px-6 pt-4 border-b border-border bg-card shrink-0">
+      <div class="flex gap-6">
+        <button
+          v-for="tab in [{ k: 'secrets', label: 'Signing secrets' }, { k: 'guide', label: 'Integration guide' }]"
+          :key="tab.k"
+          class="pb-3 -mb-px text-sm font-semibold border-b-2 transition-colors"
+          :class="view === tab.k ? 'border-primary text-primary' : 'border-transparent text-muted-foreground hover:text-foreground'"
+          @click="view = tab.k as 'secrets' | 'guide'"
+        >
+          {{ tab.label }}
+        </button>
+      </div>
+    </div>
+
+    <!-- Content -->
+    <div class="flex-1 overflow-y-auto">
+      <div class="max-w-3xl mx-auto px-6 py-8">
+        <!-- Owner gate -->
+        <div v-if="!isOwner" class="rounded-xl border border-border bg-card px-6 py-14 flex flex-col items-center text-center">
+          <div class="w-12 h-12 rounded-xl bg-secondary flex items-center justify-center mb-3">
+            <Icon name="lucide:lock" size="22" class="text-muted-foreground" />
+          </div>
+          <p class="font-heading font-bold text-sm">Owners only</p>
+          <p class="text-xs text-muted-foreground mt-1 max-w-xs leading-relaxed">
+            Only workspace owners can manage SSO signing secrets. Ask an owner if you need access.
+          </p>
+        </div>
+
+        <!-- Secrets -->
+        <template v-else-if="view === 'secrets'">
+          <section class="rounded-xl border border-border bg-card overflow-hidden">
+            <div class="px-5 py-3 border-b border-border flex items-center justify-between">
+              <div>
+                <h3 class="font-heading font-bold text-sm">Signing secrets</h3>
+                <p class="text-[11px] text-muted-foreground mt-0.5">Shared JWT secrets your backend uses to sign SSO tokens.</p>
+              </div>
+              <span class="text-[11px] font-semibold text-muted-foreground tabular-nums">{{ used }} of {{ SSO_SECRET_LIMIT }} used</span>
+            </div>
+
+            <!-- Loading -->
+            <div v-if="loading" class="px-6 py-14 text-center text-sm text-muted-foreground">Loading…</div>
+
+            <!-- Empty state -->
+            <div v-else-if="!secrets.length" class="px-6 py-14 flex flex-col items-center text-center">
+              <div class="w-12 h-12 rounded-xl bg-secondary flex items-center justify-center mb-3">
+                <Icon name="lucide:key-round" size="22" class="text-primary" />
+              </div>
+              <p class="font-heading font-bold text-sm">No signing secrets yet</p>
+              <p class="text-xs text-muted-foreground mt-1 max-w-xs leading-relaxed">
+                Create a secret, then use it on your backend to sign SSO tokens for your users.
+              </p>
+              <button
+                class="mt-4 h-9 px-4 rounded-lg bg-primary text-primary-foreground text-xs font-heading font-bold hover:opacity-90 transition-all flex items-center gap-2"
+                @click="openCreate"
+              >
+                <Icon name="lucide:plus" size="14" />
+                Create secret
+              </button>
+            </div>
+
+            <!-- List -->
+            <div v-else class="divide-y divide-border">
+              <SsoSecretRow
+                v-for="s in secrets"
+                :key="s.id"
+                :secret="s"
+                :just-created="s.id === justCreatedId"
+                @toggle="onToggle(s)"
+                @rename="openRename(s)"
+                @delete="askDelete(s)"
+              />
+            </div>
+          </section>
+
+          <!-- Rotation hint -->
+          <p class="text-[11px] text-muted-foreground leading-relaxed mt-4">
+            <Icon name="lucide:refresh-cw" size="11" class="inline mr-1" />
+            <span class="font-semibold">Rotating a secret:</span> create a new one, switch your product to it, then
+            <span class="font-semibold">disable</span> the old one (re-enable if something breaks). Delete it once you're sure.
+            Tokens are verified against every enabled secret.
+          </p>
+        </template>
+
+        <!-- Integration guide -->
+        <SsoIntegrationGuide v-else />
+      </div>
+    </div>
+
+    <SsoSecretDialog
+      v-model:open="dialogOpen"
+      :mode="dialogMode"
+      :initial-label="renameTarget?.label ?? ''"
+      @submit="onDialogSubmit"
+    />
+
+    <!-- Delete confirmation -->
+    <AlertDialog v-model:open="showDelete">
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle class="font-heading">Delete this secret?</AlertDialogTitle>
+          <AlertDialogDescription>
+            <span class="font-semibold text-foreground">{{ deleteTarget?.label || 'Untitled' }}</span> will be permanently deleted.
+            Any tokens signed with it stop working immediately. This can't be undone — if you only want to pause it, disable it instead.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction class="bg-red-600 hover:bg-red-700 text-white" @click="confirmDelete">
+            Delete permanently
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  </div>
+</template>

--- a/app/pages/sso/error.vue
+++ b/app/pages/sso/error.vue
@@ -1,0 +1,64 @@
+<script setup lang="ts">
+// /sso/error — friendly interstitial shown when /api/sso/jwt fails (expired or
+// invalid token, SSO not configured, etc.). The token comes from the customer's
+// product, so the failure is the integrator's problem; we explain it gently,
+// tell the visitor to contact their admin, and after a short countdown continue
+// on to the board (logged out) — friendlier than a raw 400.
+//
+// `layout: false` keeps the public-board chrome off this standalone shell.
+definePageMeta({ layout: false, middleware: [] })
+
+useHead({ title: 'Sign-in unavailable' })
+
+// Re-validate return_to client-side (the page is directly reachable): only a
+// same-origin relative path, never protocol-relative (`//evil.com`).
+const route = useRoute()
+const rawReturn = route.query.return_to
+const returnTo = typeof rawReturn === 'string' && rawReturn.startsWith('/') && !rawReturn.startsWith('//')
+  ? rawReturn
+  : '/'
+
+const seconds = ref(3)
+let timer: ReturnType<typeof setInterval> | undefined
+
+onMounted(() => {
+  timer = setInterval(() => {
+    seconds.value -= 1
+    if (seconds.value <= 0) {
+      if (timer) clearInterval(timer)
+      navigateTo(returnTo)
+    }
+  }, 1000)
+})
+
+onBeforeUnmount(() => {
+  if (timer) clearInterval(timer)
+})
+</script>
+
+<template>
+  <div class="min-h-screen bg-background font-body flex items-center justify-center px-6 py-12">
+    <div class="w-full max-w-sm text-center">
+      <div class="w-14 h-14 rounded-2xl bg-secondary flex items-center justify-center mx-auto mb-5">
+        <Icon name="lucide:shield-alert" size="26" class="text-primary" />
+      </div>
+
+      <h1 class="font-heading text-2xl font-bold tracking-tight">We couldn't sign you in</h1>
+      <p class="mt-3 text-sm text-muted-foreground leading-relaxed">
+        Single sign-on didn't complete — the sign-in link may have expired or been misconfigured.
+        If this keeps happening, please contact your administrator.
+      </p>
+
+      <p class="mt-6 text-xs text-muted-foreground">
+        Continuing in {{ seconds }}s…
+      </p>
+      <NuxtLink
+        :to="returnTo"
+        class="mt-3 inline-flex h-9 px-4 rounded-lg border border-border bg-card text-xs font-semibold hover:bg-secondary transition-colors items-center gap-1.5"
+      >
+        Continue now
+        <Icon name="lucide:arrow-right" size="13" />
+      </NuxtLink>
+    </div>
+  </div>
+</template>

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "clsx": "^2.1.1",
     "drizzle-kit": "^0.31.10",
     "drizzle-orm": "^0.45.2",
+    "jose": "^6.2.3",
     "lucide-vue-next": "^0.577.0",
     "md-editor-v3": "^6.4.2",
     "nanoid": "^5.1.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       drizzle-orm:
         specifier: ^0.45.2
         version: 0.45.2(@cloudflare/workers-types@4.20260307.1)(@electric-sql/pglite@0.3.15)(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3))(kysely@0.28.11)(mysql2@3.15.3)(postgres@3.4.9)(prisma@7.4.2(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))
+      jose:
+        specifier: ^6.2.3
+        version: 6.2.3
       lucide-vue-next:
         specifier: ^0.577.0
         version: 0.577.0(vue@3.5.30(typescript@5.9.3))
@@ -2879,28 +2882,24 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.1':
     resolution: {integrity: sha512-WZA0CHRL/SP1TRbA5mp9htsppSEkWuQ4KsSUumYQnyl8ZdT39ntwqmz4IUHGN6p4XdSlYfJwM4rRzZLShHsGAQ==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.1':
     resolution: {integrity: sha512-qMFzxI2YlBOLW5PhblzuSWlWfwLHaneBE0xHzLrBgNtqN6mWfs+qYbhryGSXQjFYB1Dzf5w+LN5qbUTPhW7Y5g==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.1':
     resolution: {integrity: sha512-5r1X2FKnCMUPlXTWRYpHdPYUY6a1Ar/t7P24OuiEdEOmms5lyqjDRvVY1yy9Rmioh+AunQ0rWiOTPE8F9A3v5g==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.1':
     resolution: {integrity: sha512-MGFB5cVPvshR85MTJkEvqDUnuNoysrsRxd6vnk1Lf2tbiqNlXpHYZqkqOQalydienEWOHHFyyuTSYRsLfxFJ2Q==}
@@ -3129,41 +3128,49 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -4841,8 +4848,8 @@ packages:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
 
-  jose@6.2.0:
-    resolution: {integrity: sha512-xsfE1TcSCbUdo6U07tR0mvhg0flGxU8tPLbF03mirl2ukGQENhUg4ubGYQnhVH0b5stLlPM+WOqDkEl1R1y5sQ==}
+  jose@6.2.3:
+    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -7105,52 +7112,52 @@ snapshots:
       '@babel/helper-string-parser': 8.0.0-rc.2
       '@babel/helper-validator-identifier': 8.0.0-rc.2
 
-  '@better-auth/core@1.5.4(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260307.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.0)(kysely@0.28.11)(nanostores@1.1.1)':
+  '@better-auth/core@1.5.4(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260307.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.3)(kysely@0.28.11)(nanostores@1.1.1)':
     dependencies:
       '@better-auth/utils': 0.3.1
       '@better-fetch/fetch': 1.1.21
       '@standard-schema/spec': 1.1.0
       better-call: 1.3.2(zod@4.3.6)
-      jose: 6.2.0
+      jose: 6.2.3
       kysely: 0.28.11
       nanostores: 1.1.1
       zod: 4.3.6
     optionalDependencies:
       '@cloudflare/workers-types': 4.20260307.1
 
-  '@better-auth/drizzle-adapter@1.5.4(@better-auth/core@1.5.4(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260307.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.0)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260307.1)(@electric-sql/pglite@0.3.15)(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3))(kysely@0.28.11)(mysql2@3.15.3)(postgres@3.4.9)(prisma@7.4.2(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)))':
+  '@better-auth/drizzle-adapter@1.5.4(@better-auth/core@1.5.4(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260307.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.3)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260307.1)(@electric-sql/pglite@0.3.15)(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3))(kysely@0.28.11)(mysql2@3.15.3)(postgres@3.4.9)(prisma@7.4.2(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)))':
     dependencies:
-      '@better-auth/core': 1.5.4(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260307.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.0)(kysely@0.28.11)(nanostores@1.1.1)
+      '@better-auth/core': 1.5.4(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260307.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.3)(kysely@0.28.11)(nanostores@1.1.1)
       '@better-auth/utils': 0.3.1
       drizzle-orm: 0.45.2(@cloudflare/workers-types@4.20260307.1)(@electric-sql/pglite@0.3.15)(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3))(kysely@0.28.11)(mysql2@3.15.3)(postgres@3.4.9)(prisma@7.4.2(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))
 
-  '@better-auth/kysely-adapter@1.5.4(@better-auth/core@1.5.4(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260307.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.0)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(kysely@0.28.11)':
+  '@better-auth/kysely-adapter@1.5.4(@better-auth/core@1.5.4(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260307.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.3)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(kysely@0.28.11)':
     dependencies:
-      '@better-auth/core': 1.5.4(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260307.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.0)(kysely@0.28.11)(nanostores@1.1.1)
+      '@better-auth/core': 1.5.4(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260307.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.3)(kysely@0.28.11)(nanostores@1.1.1)
       '@better-auth/utils': 0.3.1
       kysely: 0.28.11
 
-  '@better-auth/memory-adapter@1.5.4(@better-auth/core@1.5.4(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260307.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.0)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)':
+  '@better-auth/memory-adapter@1.5.4(@better-auth/core@1.5.4(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260307.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.3)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)':
     dependencies:
-      '@better-auth/core': 1.5.4(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260307.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.0)(kysely@0.28.11)(nanostores@1.1.1)
+      '@better-auth/core': 1.5.4(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260307.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.3)(kysely@0.28.11)(nanostores@1.1.1)
       '@better-auth/utils': 0.3.1
 
-  '@better-auth/mongo-adapter@1.5.4(@better-auth/core@1.5.4(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260307.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.0)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(mongodb@7.1.0)':
+  '@better-auth/mongo-adapter@1.5.4(@better-auth/core@1.5.4(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260307.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.3)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(mongodb@7.1.0)':
     dependencies:
-      '@better-auth/core': 1.5.4(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260307.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.0)(kysely@0.28.11)(nanostores@1.1.1)
+      '@better-auth/core': 1.5.4(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260307.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.3)(kysely@0.28.11)(nanostores@1.1.1)
       '@better-auth/utils': 0.3.1
       mongodb: 7.1.0
 
-  '@better-auth/prisma-adapter@1.5.4(@better-auth/core@1.5.4(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260307.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.0)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3))(prisma@7.4.2(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))':
+  '@better-auth/prisma-adapter@1.5.4(@better-auth/core@1.5.4(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260307.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.3)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3))(prisma@7.4.2(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))':
     dependencies:
-      '@better-auth/core': 1.5.4(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260307.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.0)(kysely@0.28.11)(nanostores@1.1.1)
+      '@better-auth/core': 1.5.4(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260307.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.3)(kysely@0.28.11)(nanostores@1.1.1)
       '@better-auth/utils': 0.3.1
       '@prisma/client': 7.4.2(prisma@7.4.2(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3)
       prisma: 7.4.2(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
 
-  '@better-auth/telemetry@1.5.4(@better-auth/core@1.5.4(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260307.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.0)(kysely@0.28.11)(nanostores@1.1.1))':
+  '@better-auth/telemetry@1.5.4(@better-auth/core@1.5.4(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260307.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.3)(kysely@0.28.11)(nanostores@1.1.1))':
     dependencies:
-      '@better-auth/core': 1.5.4(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260307.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.0)(kysely@0.28.11)(nanostores@1.1.1)
+      '@better-auth/core': 1.5.4(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260307.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.3)(kysely@0.28.11)(nanostores@1.1.1)
       '@better-auth/utils': 0.3.1
       '@better-fetch/fetch': 1.1.21
 
@@ -10538,20 +10545,20 @@ snapshots:
 
   better-auth@1.5.4(@cloudflare/workers-types@4.20260307.1)(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260307.1)(@electric-sql/pglite@0.3.15)(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3))(kysely@0.28.11)(mysql2@3.15.3)(postgres@3.4.9)(prisma@7.4.2(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)))(mongodb@7.1.0)(mysql2@3.15.3)(prisma@7.4.2(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vue@3.5.30(typescript@5.9.3)):
     dependencies:
-      '@better-auth/core': 1.5.4(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260307.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.0)(kysely@0.28.11)(nanostores@1.1.1)
-      '@better-auth/drizzle-adapter': 1.5.4(@better-auth/core@1.5.4(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260307.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.0)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260307.1)(@electric-sql/pglite@0.3.15)(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3))(kysely@0.28.11)(mysql2@3.15.3)(postgres@3.4.9)(prisma@7.4.2(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)))
-      '@better-auth/kysely-adapter': 1.5.4(@better-auth/core@1.5.4(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260307.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.0)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(kysely@0.28.11)
-      '@better-auth/memory-adapter': 1.5.4(@better-auth/core@1.5.4(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260307.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.0)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)
-      '@better-auth/mongo-adapter': 1.5.4(@better-auth/core@1.5.4(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260307.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.0)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(mongodb@7.1.0)
-      '@better-auth/prisma-adapter': 1.5.4(@better-auth/core@1.5.4(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260307.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.0)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3))(prisma@7.4.2(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))
-      '@better-auth/telemetry': 1.5.4(@better-auth/core@1.5.4(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260307.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.0)(kysely@0.28.11)(nanostores@1.1.1))
+      '@better-auth/core': 1.5.4(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260307.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.3)(kysely@0.28.11)(nanostores@1.1.1)
+      '@better-auth/drizzle-adapter': 1.5.4(@better-auth/core@1.5.4(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260307.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.3)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260307.1)(@electric-sql/pglite@0.3.15)(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3))(kysely@0.28.11)(mysql2@3.15.3)(postgres@3.4.9)(prisma@7.4.2(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)))
+      '@better-auth/kysely-adapter': 1.5.4(@better-auth/core@1.5.4(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260307.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.3)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(kysely@0.28.11)
+      '@better-auth/memory-adapter': 1.5.4(@better-auth/core@1.5.4(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260307.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.3)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)
+      '@better-auth/mongo-adapter': 1.5.4(@better-auth/core@1.5.4(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260307.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.3)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(mongodb@7.1.0)
+      '@better-auth/prisma-adapter': 1.5.4(@better-auth/core@1.5.4(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260307.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.3)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3))(prisma@7.4.2(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))
+      '@better-auth/telemetry': 1.5.4(@better-auth/core@1.5.4(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260307.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.3)(kysely@0.28.11)(nanostores@1.1.1))
       '@better-auth/utils': 0.3.1
       '@better-fetch/fetch': 1.1.21
       '@noble/ciphers': 2.1.1
       '@noble/hashes': 2.0.1
       better-call: 1.3.2(zod@4.3.6)
       defu: 6.1.4
-      jose: 6.2.0
+      jose: 6.2.3
       kysely: 0.28.11
       nanostores: 1.1.1
       zod: 4.3.6
@@ -11874,7 +11881,7 @@ snapshots:
 
   jiti@2.6.1: {}
 
-  jose@6.2.0: {}
+  jose@6.2.3: {}
 
   js-tokens@4.0.0: {}
 

--- a/server/api/developer/sso/secrets/[id].delete.ts
+++ b/server/api/developer/sso/secrets/[id].delete.ts
@@ -1,0 +1,19 @@
+import { and, eq } from 'drizzle-orm'
+import { organizationSso } from '#layers/feedlog/server/db/schemas'
+
+// DELETE /api/developer/sso/secrets/:id — permanently delete (owner-only).
+// Tokens signed with it stop verifying immediately. Org-scoped → 404 for ids
+// that don't belong to the caller's org.
+export default defineEventHandler(async (event) => {
+  const { orgId } = await requireOrgOwner(event)
+  const id = getRouterParam(event, 'id')
+  if (!id) throw createError({ statusCode: 404, message: 'Secret not found' })
+
+  const db = useDB()
+  const [row] = await db
+    .delete(organizationSso)
+    .where(and(eq(organizationSso.id, id), eq(organizationSso.orgId, orgId)))
+    .returning({ id: organizationSso.id })
+  if (!row) throw createError({ statusCode: 404, message: 'Secret not found' })
+  return { ok: true }
+})

--- a/server/api/developer/sso/secrets/[id].patch.ts
+++ b/server/api/developer/sso/secrets/[id].patch.ts
@@ -1,0 +1,28 @@
+import { and, eq } from 'drizzle-orm'
+import { organizationSso } from '#layers/feedlog/server/db/schemas'
+
+// PATCH /api/developer/sso/secrets/:id — disable/re-enable (rotation) or rename
+// (owner-only). Scoped by org so an owner can only touch their own secrets;
+// 404 otherwise (doesn't leak existence).
+export default defineEventHandler(async (event) => {
+  const { orgId } = await requireOrgOwner(event)
+  const id = getRouterParam(event, 'id')
+  if (!id) throw createError({ statusCode: 404, message: 'Secret not found' })
+  const body = await readBody<{ enabled?: boolean; label?: string }>(event)
+
+  const patch: { enabled?: boolean; label?: string | null } = {}
+  if (typeof body?.enabled === 'boolean') patch.enabled = body.enabled
+  if (typeof body?.label === 'string') patch.label = body.label.trim().slice(0, 80) || null
+  if (Object.keys(patch).length === 0) {
+    throw createError({ statusCode: 400, message: 'Nothing to update' })
+  }
+
+  const db = useDB()
+  const [row] = await db
+    .update(organizationSso)
+    .set(patch)
+    .where(and(eq(organizationSso.id, id), eq(organizationSso.orgId, orgId)))
+    .returning()
+  if (!row) throw createError({ statusCode: 404, message: 'Secret not found' })
+  return ssoSecretToView(row)
+})

--- a/server/api/developer/sso/secrets/index.get.ts
+++ b/server/api/developer/sso/secrets/index.get.ts
@@ -1,0 +1,16 @@
+import { desc, eq } from 'drizzle-orm'
+import { organizationSso } from '#layers/feedlog/server/db/schemas'
+
+// GET /api/developer/sso/secrets — list this org's signing secrets (owner-only).
+// Secrets are returned in full: they're stored plaintext and re-revealable, so
+// the dashboard can show them again (unlike a hashed, show-once bearer key).
+export default defineEventHandler(async (event) => {
+  const { orgId } = await requireOrgOwner(event)
+  const db = useDB()
+  const rows = await db
+    .select()
+    .from(organizationSso)
+    .where(eq(organizationSso.orgId, orgId))
+    .orderBy(desc(organizationSso.createdAt))
+  return rows.map(ssoSecretToView)
+})

--- a/server/api/developer/sso/secrets/index.post.ts
+++ b/server/api/developer/sso/secrets/index.post.ts
@@ -1,0 +1,26 @@
+import { eq } from 'drizzle-orm'
+import { organizationSso } from '#layers/feedlog/server/db/schemas'
+import { SSO_SECRET_LIMIT } from '#layers/feedlog/shared/constants/sso'
+
+// POST /api/developer/sso/secrets — create a new signing secret (owner-only).
+// Body: { label? }. Enforces the per-org cap.
+export default defineEventHandler(async (event) => {
+  const { orgId } = await requireOrgOwner(event)
+  const body = await readBody<{ label?: string }>(event).catch(() => ({} as { label?: string }))
+  const db = useDB()
+
+  const existing = await db.$count(organizationSso, eq(organizationSso.orgId, orgId))
+  if (existing >= SSO_SECRET_LIMIT) {
+    throw createError({ statusCode: 409, message: `Limit of ${SSO_SECRET_LIMIT} secrets reached` })
+  }
+
+  const label = typeof body?.label === 'string' && body.label.trim()
+    ? body.label.trim().slice(0, 80)
+    : null
+  const [row] = await db
+    .insert(organizationSso)
+    .values({ orgId, secret: generateSsoSecret(), label, enabled: true })
+    .returning()
+  setResponseStatus(event, 201)
+  return ssoSecretToView(row!)
+})

--- a/server/api/sso/jwt.get.ts
+++ b/server/api/sso/jwt.get.ts
@@ -1,0 +1,151 @@
+import { and, eq } from 'drizzle-orm'
+import { uuidv7 } from 'uuidv7'
+import { organizationSso, user } from '#layers/feedlog/server/db/schemas'
+import type { SsoIdentity } from '#layers/feedlog/server/utils/sso'
+
+// GET /api/sso/jwt — third-party product SSO entry (JWT handoff).
+//
+// The customer's backend pre-signs an HS256 JWT with one of this org's shared
+// secrets and redirects the signed-in user here. The org is resolved from the
+// host, so the whole flow stays same-domain — no cross-domain hop, hence no
+// one-time-token handoff.
+//
+// `auth`, `useDB`, the sso helpers and h3 utils are auto-imported by Nitro.
+export default defineEventHandler(async (event) => {
+  const query = getQuery(event)
+  // Derive a safe return target up front — needed even on failure so the
+  // friendly error page can continue on to the board afterwards.
+  const returnTo = validateReturnTo(event, typeof query.return_to === 'string' ? query.return_to : undefined)
+
+  try {
+    const orgId = event.context.orgId
+    if (!orgId) {
+      throw createError({ statusCode: 404, message: 'Organization not found' })
+    }
+
+    const token = typeof query.jwt === 'string' ? query.jwt : ''
+    if (!token) {
+      throw createError({ statusCode: 400, message: 'Missing jwt parameter' })
+    }
+
+    const db = useDB()
+
+    // Try every enabled secret for this org (no `kid` — see schemas/sso.ts).
+    const secrets = await db
+      .select({ secret: organizationSso.secret })
+      .from(organizationSso)
+      .where(and(eq(organizationSso.orgId, orgId), eq(organizationSso.enabled, true)))
+    if (secrets.length === 0) {
+      throw createError({ statusCode: 404, message: 'SSO is not configured for this organization' })
+    }
+
+    const identity = await verifySsoJwt(token, secrets.map(s => s.secret))
+    const userId = await findOrCreateSsoUser(db, identity)
+
+    // Mint the session and mark it with ssoOrgId. createSession persists the
+    // override field because ssoOrgId carries no defaultValue (so the framework's
+    // default-fields pass can't clobber it) — verified against better-auth 1.5.4.
+    const ctx = await auth.$context
+    const sessionRow = await ctx.internalAdapter.createSession(userId, false, { ssoOrgId: orgId })
+    if (!sessionRow?.token) {
+      throw createError({ statusCode: 500, message: 'Failed to create SSO session' })
+    }
+
+    // Set the better-auth signed session cookie ourselves. Host-only on purpose
+    // (no domain attribute), so the SSO session stays bound to the exact host
+    // that minted it and never widens to a parent domain.
+    const cookie = ctx.authCookies.sessionToken
+    const value = await signSessionCookieValue(sessionRow.token, ctx.secret)
+    // better-auth's sameSite type allows capitalized variants ("Lax"); h3 wants
+    // lowercase. Runtime default is "lax" — normalize to keep both happy.
+    const rawSameSite = cookie.attributes.sameSite
+    const sameSite = typeof rawSameSite === 'string'
+      ? (rawSameSite.toLowerCase() as 'lax' | 'strict' | 'none')
+      : rawSameSite
+    setCookie(event, cookie.name, value, {
+      httpOnly: cookie.attributes.httpOnly,
+      sameSite,
+      path: cookie.attributes.path ?? '/',
+      secure: cookie.attributes.secure,
+      maxAge: ctx.sessionConfig.expiresIn,
+    })
+
+    // Invalidate the cookie cache (session_data, possibly chunked). better-auth's
+    // getSession returns the cached payload WITHOUT cross-checking session_token,
+    // so a leftover cache from a prior login (e.g. an existing Google session on
+    // this host) would otherwise win and mask the new SSO session for up to its
+    // maxAge. Clearing it forces the next getSession to read the fresh session
+    // from the DB (and re-cache it).
+    //
+    // The deletion must carry the cookie's own attributes — matching better-auth's
+    // expireCookie. Under secure cookies the name is `__Secure-…`, and a browser
+    // rejects any Set-Cookie for a `__Secure-`-prefixed name that omits Secure.
+    const dataCookie = ctx.authCookies.sessionData
+    const dataRawSameSite = dataCookie.attributes.sameSite
+    const dataSameSite = typeof dataRawSameSite === 'string'
+      ? (dataRawSameSite.toLowerCase() as 'lax' | 'strict' | 'none')
+      : dataRawSameSite
+    const dataDeleteOpts = {
+      path: dataCookie.attributes.path ?? '/',
+      secure: dataCookie.attributes.secure,
+      httpOnly: dataCookie.attributes.httpOnly,
+      sameSite: dataSameSite,
+    }
+    const dataCookieName = dataCookie.name
+    for (const name of Object.keys(parseCookies(event))) {
+      if (name === dataCookieName || name.startsWith(`${dataCookieName}.`)) {
+        deleteCookie(event, name, dataDeleteOpts)
+      }
+    }
+
+    return sendRedirect(event, returnTo, 302)
+  }
+  catch (err) {
+    // The token comes from the customer's product, so a failure is the
+    // integrator's problem, not the visitor's. Instead of a raw 400, send a
+    // friendly interstitial (contact admin) that auto-continues to the board
+    // logged out. Log the real reason server-side for the integrator to debug.
+    console.warn('[sso] login failed:', (err as { statusMessage?: string })?.statusMessage ?? (err as Error)?.message)
+    return sendRedirect(event, `/sso/error?return_to=${encodeURIComponent(returnTo)}`, 302)
+  }
+})
+
+// Identity key = email. emailVerified=true so a later verified
+// Google/password login can be linked onto this row instead of being rejected
+// and locking the email out. ON CONFLICT keeps concurrent first-touch
+// requests for the same email from racing on the unique email constraint.
+//
+// Insert-only: an existing row is reused as-is, never updated. The `user` row is
+// global (one per email across all orgs) and this runs before the session's
+// host-binding collar exists — updating name/image here would let an org
+// overwrite a user's global profile from outside its own board, escaping the
+// host-bounded residual. Profile staleness for a pure-SSO user is the accepted
+// trade-off (matches the "email change = new user, no history migration" stance).
+async function findOrCreateSsoUser(db: ReturnType<typeof useDB>, identity: SsoIdentity): Promise<string> {
+  const existing = await db
+    .select({ id: user.id })
+    .from(user)
+    .where(eq(user.email, identity.email))
+    .limit(1)
+  if (existing[0]) return existing[0].id
+
+  await db.insert(user)
+    .values({
+      id: uuidv7(),
+      email: identity.email,
+      name: identity.name,
+      image: identity.image,
+      emailVerified: true,
+    })
+    .onConflictDoNothing({ target: user.email })
+
+  const row = await db
+    .select({ id: user.id })
+    .from(user)
+    .where(eq(user.email, identity.email))
+    .limit(1)
+  if (!row[0]) {
+    throw createError({ statusCode: 500, message: 'Failed to resolve SSO user' })
+  }
+  return row[0].id
+}

--- a/server/db/migrations/0005_silky_silver_fox.sql
+++ b/server/db/migrations/0005_silky_silver_fox.sql
@@ -1,0 +1,12 @@
+CREATE TABLE "organization_sso" (
+	"id" text PRIMARY KEY NOT NULL,
+	"org_id" text NOT NULL,
+	"secret" text NOT NULL,
+	"label" text,
+	"enabled" boolean DEFAULT true NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "session" ADD COLUMN "sso_org_id" text;--> statement-breakpoint
+ALTER TABLE "organization_sso" ADD CONSTRAINT "organization_sso_org_id_organization_id_fk" FOREIGN KEY ("org_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "idx_organization_sso_org" ON "organization_sso" USING btree ("org_id");

--- a/server/db/migrations/meta/0005_snapshot.json
+++ b/server/db/migrations/meta/0005_snapshot.json
@@ -1,0 +1,1890 @@
+{
+  "id": "bbad398d-7575-47bd-849b-6bb9c2d3c2c4",
+  "prevId": "4a63fb44-e837-4c4c-8271-e93986979524",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board": {
+      "name": "board",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_board_org_position": {
+          "name": "idx_board_org_position",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.changelog": {
+      "name": "changelog",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(300)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(70)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "categories": {
+          "name": "categories",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "cover": {
+          "name": "cover",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_title": {
+          "name": "published_title",
+          "type": "varchar(70)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_content": {
+          "name": "published_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_categories": {
+          "name": "published_categories",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_cover": {
+          "name": "published_cover",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_changelog_org_public": {
+          "name": "idx_changelog_org_public",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"published_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"changelog\".\"published_at\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_changelog_org_admin": {
+          "name": "idx_changelog_org_admin",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"updated_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_changelog_org_slug": {
+          "name": "idx_changelog_org_slug",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_changelog_title_trgm": {
+          "name": "idx_changelog_title_trgm",
+          "columns": [
+            {
+              "expression": "\"title\" gist_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gist",
+          "with": {}
+        },
+        "idx_changelog_content_trgm": {
+          "name": "idx_changelog_content_trgm",
+          "columns": [
+            {
+              "expression": "\"content\" gist_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gist",
+          "with": {}
+        },
+        "idx_changelog_pub_title_trgm": {
+          "name": "idx_changelog_pub_title_trgm",
+          "columns": [
+            {
+              "expression": "\"published_title\" gist_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gist",
+          "with": {}
+        },
+        "idx_changelog_pub_content_trgm": {
+          "name": "idx_changelog_pub_content_trgm",
+          "columns": [
+            {
+              "expression": "\"published_content\" gist_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gist",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.changelog_reaction": {
+      "name": "changelog_reaction",
+      "schema": "",
+      "columns": {
+        "changelog_id": {
+          "name": "changelog_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "changelog_reaction_changelog_id_user_id_emoji_pk": {
+          "name": "changelog_reaction_changelog_id_user_id_emoji_pk",
+          "columns": [
+            "changelog_id",
+            "user_id",
+            "emoji"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comment": {
+      "name": "comment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_to_id": {
+          "name": "reply_to_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_count": {
+          "name": "reply_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "like_count": {
+          "name": "like_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'comment'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edited_at": {
+          "name": "edited_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_comment_top_level": {
+          "name": "idx_comment_top_level",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"comment\".\"parent_id\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_comment_top_likes": {
+          "name": "idx_comment_top_likes",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"like_count\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"comment\".\"parent_id\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_comment_children": {
+          "name": "idx_comment_children",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"comment\".\"parent_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comment_like": {
+      "name": "comment_like",
+      "schema": "",
+      "columns": {
+        "comment_id": {
+          "name": "comment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "comment_like_comment_id_user_id_pk": {
+          "name": "comment_like_comment_id_user_id_pk",
+          "columns": [
+            "comment_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invitation_org_idx": {
+          "name": "invitation_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitation_email_idx": {
+          "name": "invitation_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member": {
+      "name": "member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "member_userId_idx": {
+          "name": "member_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_org_user_unique": {
+          "name": "member_org_user_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_sso": {
+      "name": "organization_sso",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_organization_sso_org": {
+          "name": "idx_organization_sso_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_sso_org_id_organization_id_fk": {
+          "name": "organization_sso_org_id_organization_id_fk",
+          "tableFrom": "organization_sso",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post": {
+      "name": "post",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(300)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "excerpt": {
+          "name": "excerpt",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote_count": {
+          "name": "vote_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "comment_count": {
+          "name": "comment_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "merged_to": {
+          "name": "merged_to",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_post_org_created": {
+          "name": "idx_post_org_created",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_post_org_votes": {
+          "name": "idx_post_org_votes",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"vote_count\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_post_org_board_created": {
+          "name": "idx_post_org_board_created",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_post_org_board_votes": {
+          "name": "idx_post_org_board_votes",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"vote_count\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_post_org_board_status": {
+          "name": "idx_post_org_board_status",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_post_org_status_votes": {
+          "name": "idx_post_org_status_votes",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"vote_count\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_post_org_slug": {
+          "name": "idx_post_org_slug",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_post_merged_to": {
+          "name": "idx_post_merged_to",
+          "columns": [
+            {
+              "expression": "merged_to",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"post\".\"merged_to\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_embedding": {
+      "name": "post_embedding",
+      "schema": "",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(768)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_post_embedding_org": {
+          "name": "idx_post_embedding_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "post_embedding_post_id_post_id_fk": {
+          "name": "post_embedding_post_id_post_id_fk",
+          "tableFrom": "post_embedding",
+          "tableTo": "post",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_search": {
+      "name": "post_search",
+      "schema": "",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "search_text": {
+          "name": "search_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_post_search_org": {
+          "name": "idx_post_search_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "post_search_post_id_post_id_fk": {
+          "name": "post_search_post_id_post_id_fk",
+          "tableFrom": "post_search",
+          "tableTo": "post",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sso_org_id": {
+          "name": "sso_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vote": {
+      "name": "vote",
+      "schema": "",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "vote_post_id_user_id_pk": {
+          "name": "vote_post_id_user_id_pk",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/server/db/migrations/meta/_journal.json
+++ b/server/db/migrations/meta/_journal.json
@@ -1,41 +1,48 @@
 {
-	"version": "7",
-	"dialect": "postgresql",
-	"entries": [
-		{
-			"idx": 0,
-			"version": "7",
-			"when": 1773653078089,
-			"tag": "0000_perpetual_moonstone",
-			"breakpoints": true
-		},
-		{
-			"idx": 1,
-			"version": "7",
-			"when": 1775182014664,
-			"tag": "0001_open_lorna_dane",
-			"breakpoints": true
-		},
-		{
-			"idx": 2,
-			"version": "7",
-			"when": 1775800650384,
-			"tag": "0002_yellow_spectrum",
-			"breakpoints": true
-		},
-		{
-			"idx": 3,
-			"version": "7",
-			"when": 1777056000000,
-			"tag": "0003_seed_defaults",
-			"breakpoints": true
-		},
-		{
-			"idx": 4,
-			"version": "7",
-			"when": 1779580800000,
-			"tag": "0004_member_management",
-			"breakpoints": true
-		}
-	]
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1773653078089,
+      "tag": "0000_perpetual_moonstone",
+      "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1775182014664,
+      "tag": "0001_open_lorna_dane",
+      "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1775800650384,
+      "tag": "0002_yellow_spectrum",
+      "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1777056000000,
+      "tag": "0003_seed_defaults",
+      "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1779580800000,
+      "tag": "0004_member_management",
+      "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1779947828444,
+      "tag": "0005_silky_silver_fox",
+      "breakpoints": true
+    }
+  ]
 }

--- a/server/db/schemas/auth.ts
+++ b/server/db/schemas/auth.ts
@@ -37,6 +37,12 @@ export const session = pgTable(
     // organization plugin: tracks "last visited org" — UX convenience only,
     // never used for data isolation. event.context.orgId comes from host.
     activeOrganizationId: text("active_organization_id"),
+    // Set only on sessions minted by the product-SSO endpoint (/api/sso/jwt).
+    // Marks an end-user session whose email was asserted by the org (not
+    // verified by FeedLog): host-bound to this org, blocked from credential
+    // changes. Null for normal Google/GitHub/password logins. Declared as a
+    // better-auth session.additionalField in server/utils/better-auth.ts.
+    ssoOrgId: text("sso_org_id"),
   },
   (table) => [index("session_userId_idx").on(table.userId)],
 );

--- a/server/db/schemas/index.ts
+++ b/server/db/schemas/index.ts
@@ -17,6 +17,10 @@ export {
   memberRelations,
   invitationRelations,
 } from './auth'
+export {
+  organizationSso,
+  organizationSsoRelations,
+} from './sso'
 import { user, session, account, organization, member, invitation } from './auth'
 
 // Custom type for pgvector's vector column

--- a/server/db/schemas/sso.ts
+++ b/server/db/schemas/sso.ts
@@ -1,0 +1,29 @@
+import { pgTable, text, boolean, timestamp, index } from 'drizzle-orm/pg-core'
+import { relations } from 'drizzle-orm'
+import { uuidv7 } from 'uuidv7'
+import { organization } from './auth'
+
+// Per-org HS256 signing secrets for third-party product SSO (JWT handoff).
+//
+// 1:N — an org may hold several secrets so rotation is just CRUD: create a new
+// one, switch the product to it, disable the old one (re-enable if something
+// breaks), delete once confident. Verification tries every enabled secret, so
+// the customer never sends a `kid`. Logical cap of 5 per org enforced in the API.
+//
+// `secret` is stored in PLAINTEXT: HMAC verification needs the raw value and the
+// dashboard re-reveals it on demand (unlike a hashed, show-once bearer key).
+// Treat it as a high-value credential at the DB / access-control layer.
+export const organizationSso = pgTable('organization_sso', {
+  id: text('id').primaryKey().$defaultFn(() => uuidv7()),
+  orgId: text('org_id').notNull().references(() => organization.id, { onDelete: 'cascade' }),
+  secret: text('secret').notNull(),
+  label: text('label'),
+  enabled: boolean('enabled').notNull().default(true),
+  createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+}, (t) => [
+  index('idx_organization_sso_org').on(t.orgId),
+])
+
+export const organizationSsoRelations = relations(organizationSso, ({ one }) => ({
+  organization: one(organization, { fields: [organizationSso.orgId], references: [organization.id] }),
+}))

--- a/server/middleware/sso-session-guard.ts
+++ b/server/middleware/sso-session-guard.ts
@@ -1,0 +1,46 @@
+// Blocks identity elevation on product-SSO sessions.
+//
+// An SSO session asserts an org-provided email that FeedLog never verified, so
+// it must not set/change a password, change email, edit profile, or bind a
+// login method — any of which would turn a borrowed email into a fully-owned
+// account. Nor may it reach org-management or admin endpoints: better-auth's
+// organization plugin enforces permission off the member table, and its admin
+// plugin off user.role — both bypass our requireOrg* gates and the host-binding
+// collar, so an SSO session whose email matches an owner/admin could otherwise
+// drive them. Blocking the /api/auth/organization/ and /api/auth/admin/ prefixes
+// wholesale stays robust as better-auth adds endpoints.
+//
+// Keyed on session.ssoOrgId, NOT user.emailVerified: the latter is global and a
+// separate verified login could flip it true for an SSO session to ride on.
+// `auth` is auto-imported.
+
+const BLOCKED_AUTH_ENDPOINTS = new Set([
+  'set-password',
+  'change-password',
+  'change-email',
+  'update-user',
+  'delete-user',
+  'link-social',
+  'unlink-account',
+])
+
+function isBlockedForSso(path: string): boolean {
+  if (!path.startsWith('/api/auth/')) return false
+  const rest = path.slice('/api/auth/'.length)
+  if (rest.startsWith('organization/') || rest.startsWith('admin/')) return true
+  const suffix = rest.split(/[?/]/)[0]
+  return !!suffix && BLOCKED_AUTH_ENDPOINTS.has(suffix)
+}
+
+export default defineEventHandler(async (event) => {
+  if (!isBlockedForSso(event.path)) return
+
+  const session = await auth.api.getSession({ headers: event.headers })
+  const ssoOrgId = (session?.session as { ssoOrgId?: string | null } | undefined)?.ssoOrgId
+  if (ssoOrgId) {
+    throw createError({
+      statusCode: 403,
+      message: 'SSO sessions cannot manage credentials, profile, or organization',
+    })
+  }
+})

--- a/server/utils/auth.ts
+++ b/server/utils/auth.ts
@@ -11,7 +11,18 @@ import type { H3Event } from 'h3'
 export type OrgPermissionStatement = Record<string, string[]>
 
 export async function getUserSession(event: H3Event) {
-  return auth.api.getSession({ headers: event.headers })
+  const result = await auth.api.getSession({ headers: event.headers })
+  if (!result) return null
+  // Host-binding collar: a product-SSO session is valid only on the
+  // org host that minted it. On any other host — e.g. a token replayed to a
+  // different org's host — treat it as unauthenticated so it can't reach
+  // staff surfaces or another org's data. Single-tenant deployments: ssoOrgId
+  // always equals the default org → no-op. Every requireAuth* helper inherits this.
+  const ssoOrgId = (result.session as { ssoOrgId?: string | null }).ssoOrgId
+  if (ssoOrgId && ssoOrgId !== event.context.orgId) {
+    return null
+  }
+  return result
 }
 
 // Throws 401 if not authenticated.
@@ -23,6 +34,21 @@ export async function requireAuth(event: H3Event) {
   return session
 }
 
+// A product-SSO session is an end-user identity only, never staff. Even when
+// its email happens to match an org member/owner
+// row, the org never intended a product's SSO handoff to confer dashboard /
+// staff access; granting it would silently elevate a borrowed-email session.
+// The host-binding collar only stops the *cross-org* case (member of a
+// different org); this closes the same-org coincidence. End-user write paths
+// (requireAuthInOrg) deliberately don't call this — posting/voting/commenting
+// is exactly what an SSO end-user is for.
+function assertNotSsoSession(session: Awaited<ReturnType<typeof requireAuth>>) {
+  const ssoOrgId = (session.session as { ssoOrgId?: string | null }).ssoOrgId
+  if (ssoOrgId) {
+    throw createError({ statusCode: 403, message: 'SSO sessions cannot access staff areas' })
+  }
+}
+
 // Throws 403 if the current user lacks any of the requested actions in the
 // active org. Combines "is a member of this org" and "role grants action" in
 // one call — both checks delegate to better-auth's hasPermission internals.
@@ -31,13 +57,14 @@ export async function requireOrgPermission(
   permissions: OrgPermissionStatement,
 ) {
   const session = await requireAuth(event)
+  assertNotSsoSession(session)
   const orgId = event.context.orgId
   if (!orgId) {
     throw createError({ statusCode: 500, message: 'orgId missing from request context' })
   }
   // Cast: customSession's $Infer return shadows organization plugin endpoint
   // typing in InferAPI; the underlying hasPermission endpoint still exists at
-  // runtime. https://github.com/better-auth/better-auth/issues/* (cf-#3?)
+  // runtime.
   const orgApi = auth.api as unknown as {
     hasPermission: (input: {
       headers: Headers
@@ -56,9 +83,8 @@ export async function requireOrgPermission(
 
 // End-user write paths (post / vote / comment / reaction). End-users and
 // staff share the same write surface — both authenticate, both write under
-// the active org. orgId comes from event.context (set by
-// middleware/org-context.ts: default-org in single-tenant, parsed from the
-// subdomain in multi-tenant), not from session.activeOrganizationId. Use
+// the active org. orgId comes from event.context (resolved per request by
+// middleware/org-context.ts), not from session.activeOrganizationId. Use
 // this — not requireOrgMember — for any surface a non-member should reach.
 // Mirrors requireOrgMember's return shape so call sites diff cleanly.
 export async function requireAuthInOrg(event: H3Event) {
@@ -74,6 +100,7 @@ export async function requireAuthInOrg(event: H3Event) {
 // Permission-less — for fine-grained checks use requireOrgPermission.
 export async function requireOrgMember(event: H3Event) {
   const session = await requireAuth(event)
+  assertNotSsoSession(session)
   const orgId = event.context.orgId
   if (!orgId) {
     throw createError({ statusCode: 500, message: 'orgId missing from request context' })
@@ -84,4 +111,14 @@ export async function requireOrgMember(event: H3Event) {
     throw createError({ statusCode: 403, message: 'Not a member of this organization' })
   }
   return { session, orgId, role: found.role }
+}
+
+// Gate a dashboard surface on "current user is owner of this org". Used for
+// owner-only settings such as SSO signing secrets.
+export async function requireOrgOwner(event: H3Event) {
+  const result = await requireOrgMember(event)
+  if (result.role !== 'owner') {
+    throw createError({ statusCode: 403, message: 'Owner role required' })
+  }
+  return result
 }

--- a/server/utils/better-auth.ts
+++ b/server/utils/better-auth.ts
@@ -81,7 +81,7 @@ const emailVerification = hasEmailProvider
 
 // Build the orgList shape attached to every session via customSession plugin.
 // Cookie cache (60s) keeps this off the DB hot path; ≤60s staleness on role
-// changes is acceptable per tech.md §3.2.
+// changes is acceptable.
 async function loadOrgList(userId: string) {
   const rows = await db
     .select({
@@ -168,6 +168,13 @@ export function buildAuthConfig(overrides: AuthConfigOverrides = {}): BetterAuth
       ...(overrides.extraPlugins ?? []),
     ],
     session: {
+      additionalFields: {
+        // Product-SSO marker (see schemas/auth.ts session.ssoOrgId). Written by
+        // the /api/sso/jwt endpoint via internalAdapter.createSession override.
+        // input:false — clients can't forge it through the API; returned:true —
+        // surfaced in getSession so the UI can gate credential controls.
+        ssoOrgId: { type: 'string', required: false, input: false, returned: true },
+      },
       cookieCache: { enabled: true, maxAge: 60 },
     },
     databaseHooks: {

--- a/server/utils/sso.ts
+++ b/server/utils/sso.ts
@@ -1,0 +1,137 @@
+import type { H3Event } from 'h3'
+import { getRequestURL } from 'h3'
+import { jwtVerify } from 'jose'
+
+// Product-SSO helpers: verify the customer-signed HS256 JWT, guard the
+// return_to target against open redirects, and produce the signed session
+// cookie value.
+
+// exp is required on every token. We reject tokens whose exp is more than this
+// far in the future — a leaked pre-signed token stays usable only this long.
+// Replay severity is already capped by the ssoOrgId session collar, so the TTL
+// governs probability, not blast radius.
+const MAX_TTL_SECONDS = 24 * 60 * 60
+const CLOCK_TOLERANCE_SECONDS = 60
+
+export interface SsoIdentity {
+  email: string
+  name: string
+  image: string | null
+}
+
+// Verify against every enabled secret until one matches (no `kid` needed on the
+// customer side). jose's jwtVerify already enforces exp with clock tolerance;
+// we add the hard upper bound on how far exp may sit in the future.
+export async function verifySsoJwt(token: string, secrets: string[]): Promise<SsoIdentity> {
+  const enc = new TextEncoder()
+  let payload: Record<string, unknown> | null = null
+  for (const secret of secrets) {
+    try {
+      const res = await jwtVerify(token, enc.encode(secret), {
+        algorithms: ['HS256'],
+        clockTolerance: CLOCK_TOLERANCE_SECONDS,
+      })
+      payload = res.payload as Record<string, unknown>
+      break
+    }
+    catch {
+      // Signature/exp mismatch — try the next enabled secret.
+    }
+  }
+  if (!payload) {
+    throw createError({ statusCode: 400, message: 'Invalid or expired SSO token' })
+  }
+
+  const exp = payload.exp
+  if (typeof exp !== 'number') {
+    throw createError({ statusCode: 400, message: 'SSO token must carry an exp claim' })
+  }
+  const now = Math.floor(Date.now() / 1000)
+  if (exp - now > MAX_TTL_SECONDS + CLOCK_TOLERANCE_SECONDS) {
+    throw createError({ statusCode: 400, message: 'SSO token exp is too far in the future' })
+  }
+
+  // email is the identity key — hard-required. name backs a NOT NULL
+  // column; fall back to the email when the org omits it. All other claims are
+  // ignored (no custom-field mechanism).
+  const email = payload.email
+  if (typeof email !== 'string' || !email.includes('@')) {
+    throw createError({ statusCode: 400, message: 'SSO token must carry a valid email claim' })
+  }
+  const normalizedEmail = email.trim().toLowerCase()
+  const name = typeof payload.name === 'string' && payload.name.trim()
+    ? payload.name.trim()
+    : normalizedEmail
+  const image = typeof payload.picture === 'string' && payload.picture
+    ? payload.picture
+    : null
+
+  return { email: normalizedEmail, name, image }
+}
+
+// Open-redirect guard for return_to. Allows only a same-host relative path
+// or a same-host absolute URL; everything else falls back to "/". Rejects
+// protocol-relative ("//evil.com") and backslash tricks before parsing.
+export function validateReturnTo(event: H3Event, returnTo: string | undefined | null): string {
+  if (!returnTo) return '/'
+  if (returnTo.includes('\\') || returnTo.startsWith('//')) return '/'
+  const reqUrl = getRequestURL(event)
+  try {
+    const url = new URL(returnTo, reqUrl.origin)
+    if (url.host !== reqUrl.host) return '/'
+    return url.pathname + url.search + url.hash
+  }
+  catch {
+    return '/'
+  }
+}
+
+// A raw signing secret: 32 random bytes (256 bits) as hex, no prefix.
+// crypto.getRandomValues is edge-safe (CF Workers / Vercel / Node).
+export function generateSsoSecret(): string {
+  const bytes = new Uint8Array(32)
+  crypto.getRandomValues(bytes)
+  let hex = ''
+  for (let i = 0; i < bytes.length; i++) hex += bytes[i]!.toString(16).padStart(2, '0')
+  return hex
+}
+
+export interface SsoSecretView {
+  id: string
+  label: string | null
+  secret: string
+  enabled: boolean
+  createdAt: string
+}
+
+// secret is included (plaintext, recoverable) so the dashboard row can
+// re-reveal it — see schemas/sso.ts.
+export function ssoSecretToView(row: {
+  id: string
+  label: string | null
+  secret: string
+  enabled: boolean
+  createdAt: Date | string
+}): SsoSecretView {
+  return {
+    id: row.id,
+    label: row.label,
+    secret: row.secret,
+    enabled: row.enabled,
+    createdAt: row.createdAt instanceof Date ? row.createdAt.toISOString() : row.createdAt,
+  }
+}
+
+// Reproduce better-call's signed-cookie value: `${token}.${base64(HMAC-SHA256)}`.
+// We return it UN-encoded — h3's setCookie (cookie-es) URL-encodes the value
+// exactly once on the way out, matching better-call byte-for-byte. WebCrypto so
+// this runs on CF Workers / edge as well as Node.
+export async function signSessionCookieValue(token: string, secret: string): Promise<string> {
+  const enc = new TextEncoder()
+  const key = await crypto.subtle.importKey('raw', enc.encode(secret), { name: 'HMAC', hash: 'SHA-256' }, false, ['sign'])
+  const sig = await crypto.subtle.sign('HMAC', key, enc.encode(token))
+  const bytes = new Uint8Array(sig)
+  let bin = ''
+  for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i]!)
+  return `${token}.${btoa(bin)}`
+}

--- a/shared/constants/sso.ts
+++ b/shared/constants/sso.ts
@@ -1,0 +1,7 @@
+// Product-SSO constants shared between the secret-management API (cap
+// enforcement) and the dashboard UI (create-button gating).
+
+// Logical cap on signing secrets per org. Multiple secrets exist only to make
+// rotation a CRUD operation (create new → switch product → disable old →
+// delete); 5 is plenty of headroom for that without becoming a sprawl.
+export const SSO_SECRET_LIMIT = 5


### PR DESCRIPTION
## Summary

Adds third-party product SSO so a product's already-signed-in users can reach their FeedLog feedback board without a second login. The customer's backend pre-signs a short-lived HS256 JWT and redirects the user to `GET /api/sso/jwt`, which verifies the token against the org's signing secrets, finds-or-creates the end user by email, mints a host-bound session, and redirects to `return_to`. Same-domain throughout — no cross-domain hop, no one-time-token handoff.

## What's included

- **Handoff endpoint** `GET /api/sso/jwt` — algorithm-confined HS256 verify, `exp` required + 24h max-TTL cap (±60s clock tolerance), find-or-create user by email, host-only session cookie, friendly `/sso/error` interstitial on failure (logs the real reason server-side).
- **Owner-managed signing secrets** — Dashboard → Developer → Single Sign-On: create / rename / enable-disable / delete, with CRUD-style rotation (verification tries every enabled secret, so no `kid`). Per-org cap of 5.
- **Integration guide** — endpoint, JWT payload fields (`email`, `name`, `picture`, `exp`), copy-paste Node signing snippet, TTL guidance.
- **Security guards**
  - *Host-binding collar* — an SSO session is valid only on the org host that minted it (single-tenant deployments: no-op).
  - *Identity-elevation guard* — SSO sessions are blocked (403) from credential changes (`set/change-password`, `change-email`, `update-user`, `link/unlink-account`) and from the `/api/auth/organization/` and `/api/auth/admin/` namespaces, even if the email matches an org member/owner. Staff/dashboard surfaces 403 likewise; anonymous stays 401.

## Design notes

- Signing secrets are stored in plaintext by design — HMAC verification needs the raw value and the dashboard re-reveals them on demand (unlike a hashed, show-once bearer key). Treat the table as a high-value credential at the DB / access-control layer.
- Identity key is `email`; `emailVerified` is set true so a later verified Google/password login links onto the same row rather than being locked out. Email change = new user (no history migration).
- The `ssoOrgId` session field is `input:false` (clients can't forge it) and persisted via `internalAdapter.createSession` override; the session-cookie value is reproduced to match better-auth/better-call byte-for-byte (WebCrypto, edge-safe).

## Regression testing (local, OSS single-tenant)

- ✅ **Production build** (`pnpm build`, node preset) — clean; SSO routes + `0005` migration bundled.
- ✅ **SSO handoff e2e** — valid token → 302 + host-only `HttpOnly` session cookie + `session.ssoOrgId` set + user created; expired / bad-signature / `exp`-too-far → `/sso/error`; `return_to=//evil.com` → falls back to `/`.
- ✅ **Guards** — `update-user`, `organization/list`, `admin/list-users`, owner-only secrets API all 403 for SSO sessions; anonymous 401.
- ✅ **Core flows** — signup/login, post, vote, comment, dashboard, SSO settings + integration guide UI — no console errors.
- ℹ️ Errors from `nuxi typecheck` are all pre-existing (the repo doesn't currently gate on typecheck; `vue-tsc` isn't a dep); this change introduces none.
