### PR TITLE
Email notification

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ overrides, and authentication toggles.
 - **Similar-idea merge** — Vector embeddings (OpenAI `text-embedding-3-large`, 768-dim) surface duplicate feedback before it fragments the board.
 - **Authentication** — Email / password, Google OAuth, GitHub OAuth, admin role handling — powered by [better-auth](https://www.better-auth.com).
 - **Comments & discussions** — Markdown-powered threads on every post.
+- **Notifications** — Authors and upvoters are subscribed automatically and emailed when a post's status changes or the team replies officially; unsubscribe per post at any time. Admins aren't notified. Requires an email provider.
 
 ## Tech Stack
 

--- a/app/components/LocaleSwitcher.vue
+++ b/app/components/LocaleSwitcher.vue
@@ -1,6 +1,10 @@
 <script setup lang="ts">
 // Standalone language switcher (top-bar icon), sits next to ThemeSwitcher.
 const { locale, locales, setLocale } = useI18n()
+
+async function switchLocale(code: string) {
+  await setLocale(code as never)
+}
 </script>
 
 <template>
@@ -19,7 +23,7 @@ const { locale, locales, setLocale } = useI18n()
         v-for="l in locales"
         :key="l.code"
         class="cursor-pointer"
-        @click="setLocale(l.code)"
+        @click="switchLocale(l.code)"
       >
         <span class="flex-1">{{ l.name ?? l.code }}</span>
         <Icon v-if="locale === l.code" name="lucide:check" size="14" class="text-primary" />

--- a/app/components/comment/CommentEditor.vue
+++ b/app/components/comment/CommentEditor.vue
@@ -7,20 +7,25 @@ const props = withDefaults(defineProps<{
   placeholder?: string
   initialContent?: string
   loading?: boolean
+  canNotify?: boolean
 }>(), {
   loading: false,
+  canNotify: false,
 })
 
 const emit = defineEmits<{
-  submit: [content: string]
+  submit: [content: string, notify: boolean]
   cancel: []
 }>()
 
 const content = ref(props.initialContent ?? '')
 const error = ref('')
+const notify = ref(true)
 
 const isReply = computed(() => !!props.parentId)
 const isEditing = computed(() => !!props.initialContent)
+const showNotify = computed(() => props.canNotify && !isReply.value && !isEditing.value)
+const submitDisabled = computed(() => !content.value.trim() || props.loading)
 
 const { onUploadImg } = useUploadImg()
 
@@ -30,12 +35,13 @@ const footers = ['=', 0] as const
 function handleSubmit() {
   const text = content.value.trim()
   if (!text) return
-  emit('submit', text)
+  emit('submit', text, showNotify.value ? notify.value : true)
 }
 
 function clear() {
   content.value = ''
   error.value = ''
+  notify.value = true
 }
 
 defineExpose({ clear })
@@ -65,14 +71,56 @@ defineExpose({ clear })
           >
             {{ $t('common.cancel') }}
           </Button>
-          <Button
-            variant="default"
-            size="sm"
-            :disabled="!content.trim() || loading"
-            @click="handleSubmit"
-          >
-            {{ isEditing ? $t('common.save') : (isReply ? $t('post.comment.reply') : $t('post.comment.comment')) }}
-        </Button>
+          <div class="flex items-center">
+            <Button
+              variant="default"
+              size="sm"
+              :class="showNotify ? 'rounded-r-none' : ''"
+              :disabled="submitDisabled"
+              @click="handleSubmit"
+            >
+              {{ isEditing ? $t('common.save') : (isReply ? $t('post.comment.reply') : $t('post.comment.comment')) }}
+            </Button>
+            <DropdownMenu v-if="showNotify">
+              <DropdownMenuTrigger as-child>
+                <Button
+                  variant="default"
+                  size="sm"
+                  class="rounded-l-none border-l border-primary-foreground/25 px-2"
+                  :disabled="submitDisabled"
+                  :aria-label="$t('post.comment.emailUpvoters')"
+                >
+                  <Icon name="lucide:more-vertical" size="14" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" class="min-w-[240px]">
+                <DropdownMenuLabel class="text-[11px] font-bold uppercase tracking-wider text-muted-foreground">
+                  {{ $t('post.comment.emailUpvoters') }}
+                </DropdownMenuLabel>
+                <!-- select.prevent: toggling must not dismiss the menu. -->
+                <DropdownMenuItem
+                  class="cursor-pointer gap-3 py-2"
+                  :title="$t('post.comment.notifyUpvotersHint')"
+                  @select.prevent="notify = !notify"
+                >
+                  <!-- ring: the item's accent-tinted focus background would
+                       otherwise swallow the primary "on" track. -->
+                  <span
+                    class="relative h-5 w-9 shrink-0 rounded-full ring-1 ring-inset ring-foreground/20 transition-colors"
+                    :class="notify ? 'bg-primary' : 'bg-muted'"
+                  >
+                    <span
+                      class="absolute left-0.5 top-0.5 flex h-4 w-4 items-center justify-center rounded-full bg-white shadow transition-transform"
+                      :class="notify ? 'translate-x-4' : ''"
+                    >
+                      <Icon name="lucide:bell" size="10" class="text-muted-foreground" />
+                    </span>
+                  </span>
+                  <span class="text-sm font-medium">{{ $t('post.comment.notifyUpvoters') }}</span>
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
         </div>
       </template>
     </ThemedMdEditor>

--- a/app/components/post/PostDetail.vue
+++ b/app/components/post/PostDetail.vue
@@ -131,10 +131,33 @@ async function handleDeletePost() {
 }
 
 // ---- Admin sidebar actions ----
+// Status changes apply immediately and silently; this prompt (when set to the
+// new status) then asks whether to mail the subscribers.
+const notifyStatus = ref<string | null>(null)
+
 async function handleStatusChange(status: string) {
-  if (!post.value || !isOrgManager.value) return
+  if (!post.value || !isOrgManager.value || post.value.status === status) return
   await store.updatePost(props.slug, { status }, true)
   emit('updated', { id: post.value.id, slug: post.value.slug, status })
+  notifyStatus.value = status
+}
+
+async function sendStatusNotification(note: string) {
+  const status = notifyStatus.value
+  if (!post.value || !status) return
+  notifyStatus.value = null
+  try {
+    await useApiFetch(`/api/admin/posts/${post.value.id}/notify-status`, {
+      method: 'POST',
+      body: { status, note: note || undefined },
+    })
+  }
+  catch (err: unknown) {
+    // 409 = status changed under the admin between the write and the send.
+    if ((err as { statusCode?: number })?.statusCode === 409) {
+      console.error('[notifications] status changed by someone else')
+    }
+  }
 }
 
 async function handleBoardChange(boardId: string | null) {
@@ -209,10 +232,10 @@ function emitCommentCount() {
 }
 
 // Comment handlers
-async function handleCommentSubmit(content: string) {
+async function handleCommentSubmit(content: string, notify: boolean) {
   commentSubmitting.value = true
   try {
-    await store.addComment(props.slug, content)
+    await store.addComment(props.slug, content, { notify })
     commentEditorRef.value?.clear()
     emitCommentCount()
   } finally {
@@ -226,7 +249,7 @@ async function handleReplySubmit(content: string) {
   try {
     const { parentId, commentId } = replyingTo.value
     const replyToId = commentId !== parentId ? commentId : undefined
-    await store.addComment(props.slug, content, parentId, replyToId)
+    await store.addComment(props.slug, content, { parentId, replyToId })
     replyingTo.value = null
     emitCommentCount()
   } finally {
@@ -418,7 +441,7 @@ async function handleShare() {
         <!-- Merge banner (inside discussion, per PRD) -->
         <MergeBanner v-if="isMerged && post.canonicalPost" :canonical-post="post.canonicalPost" />
         <ClientOnly v-if="!isMerged">
-          <CommentEditor v-if="isLoggedIn" ref="commentEditorRef" :loading="commentSubmitting" @submit="handleCommentSubmit" />
+          <CommentEditor v-if="isLoggedIn" ref="commentEditorRef" :loading="commentSubmitting" :can-notify="isOrgManager" @submit="handleCommentSubmit" />
           <CommentLoginPrompt v-else />
         </ClientOnly>
         <div v-if="commentLoading && comments.length === 0" class="space-y-4 pt-2">
@@ -488,6 +511,14 @@ async function handleShare() {
             <div class="w-3 h-3 rounded-full" :style="{ backgroundColor: `var(${(STATUS_CONFIG[post.status as keyof typeof STATUS_CONFIG] ?? STATUS_CONFIG.open).cssVar})` }" />
             <span class="font-bold text-sm">{{ $t(statusLabelKey(post.status)) }}</span>
           </div>
+          <StatusNotifyPrompt
+            v-if="notifyStatus"
+            class="mt-2"
+            :actor-name="session?.user?.name"
+            :actor-image="session?.user?.image"
+            @send="sendStatusNotification"
+            @dismiss="notifyStatus = null"
+          />
         </div>
         <div>
           <h4 class="font-heading text-[11px] font-bold text-muted-foreground uppercase tracking-wider mb-3">{{ $t('post.detail.author') }}</h4>
@@ -497,10 +528,9 @@ async function handleShare() {
             <p class="text-sm font-bold">{{ post.author?.name ?? $t('common.anonymous') }}</p>
           </div>
         </div>
+        <!-- Admins never receive post-thread email, so the card would lie to them. -->
+        <PostSubscribeCard v-if="post.id && isLoggedIn && !isOrgManager && !isMerged" :post-id="post.id" :subscribed="post.subscribed ?? false" @update:subscribed="post.subscribed = $event" />
         <div class="pt-2 flex flex-col gap-2">
-          <!-- Subscribe to Updates — hidden until the notification backend lands; unhide when ready
-          <Button variant="secondary" :disabled="isMerged" :class="isMerged ? 'opacity-50 cursor-not-allowed' : ''"><Icon name="lucide:bell" size="18" /> Subscribe to Updates</Button>
-          -->
           <Button variant="outline" class="text-primary" :disabled="isMerged" :class="isMerged ? 'opacity-50 cursor-not-allowed' : ''" @click="handleShare"><Icon name="lucide:share-2" size="18" /> {{ $t('post.detail.shareRequest') }}</Button>
         </div>
       </div>
@@ -509,6 +539,7 @@ async function handleShare() {
 
     <!-- Merge dialog -->
     <MergeDialog v-if="post.id" v-model:open="mergeDialogOpen" :post-id="post.id" :post-title="post.title" :direction="mergeDirection" @merged="handleMerged" />
+
   </template>
 </template>
 

--- a/app/components/post/PostSubscribeCard.vue
+++ b/app/components/post/PostSubscribeCard.vue
@@ -1,0 +1,44 @@
+<script setup lang="ts">
+// Subscription state comes from the post detail response (props); this card
+// only writes. Subscribe = POST, unsubscribe = DELETE.
+const props = defineProps<{ postId: string; subscribed: boolean }>()
+const emit = defineEmits<{ 'update:subscribed': [boolean] }>()
+
+const isSubscribed = ref(props.subscribed)
+const pending = ref(false)
+watchEffect(() => { isSubscribed.value = props.subscribed })
+
+async function toggle() {
+  if (pending.value) return
+  pending.value = true
+  const next = !isSubscribed.value
+  try {
+    await useApiFetch(`/api/posts/${props.postId}/subscription`, { method: next ? 'POST' : 'DELETE' })
+    isSubscribed.value = next
+    emit('update:subscribed', next)
+  }
+  finally {
+    pending.value = false
+  }
+}
+</script>
+
+<template>
+  <div>
+    <h4 class="font-heading text-[11px] font-bold uppercase tracking-wider text-muted-foreground mb-2">
+      {{ $t('post.subscribe.title') }}
+    </h4>
+    <p class="mb-3 text-xs text-muted-foreground leading-snug">{{ $t('post.subscribe.desc') }}</p>
+    <button
+      class="inline-flex items-center gap-2 rounded-lg border px-3 py-2 text-[13px] font-bold transition-colors disabled:opacity-50"
+      :class="isSubscribed
+        ? 'border-border hover:bg-secondary/50'
+        : 'border-transparent bg-primary text-primary-foreground hover:bg-primary/90'"
+      :disabled="pending"
+      @click="toggle"
+    >
+      <Icon :name="isSubscribed ? 'lucide:bell-off' : 'lucide:bell'" size="14" />
+      {{ isSubscribed ? $t('post.subscribe.unsubscribe') : $t('post.subscribe.subscribe') }}
+    </button>
+  </div>
+</template>

--- a/app/components/post/StatusNotifyPrompt.vue
+++ b/app/components/post/StatusNotifyPrompt.vue
@@ -1,0 +1,86 @@
+<script setup lang="ts">
+defineProps<{ actorName?: string; actorImage?: string | null }>()
+const emit = defineEmits<{ send: [note: string]; dismiss: [] }>()
+
+const composing = ref(false)
+const note = ref('')
+
+function send(custom: boolean) {
+  emit('send', custom ? note.value.trim() : '')
+  composing.value = false
+}
+</script>
+
+<template>
+  <div class="relative rounded-xl border border-border bg-card p-4 shadow-lg">
+    <button
+      class="absolute right-2 top-2 flex h-7 w-7 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-secondary/50 hover:text-foreground"
+      :aria-label="$t('post.statusNotify.dismiss')"
+      @click="emit('dismiss')"
+    >
+      <Icon name="lucide:x" size="15" />
+    </button>
+
+    <p class="pr-7 text-[13px] font-bold leading-tight">{{ $t('post.statusNotify.title') }}</p>
+    <p class="mt-1 text-[12px] leading-snug text-muted-foreground">{{ $t('post.statusNotify.desc') }}</p>
+
+    <!-- Stacked: side by side these overflow the sidebar and wrap mid-label. -->
+    <div class="mt-3 flex flex-col gap-2">
+      <button
+        class="w-full whitespace-nowrap rounded-lg bg-primary px-3 py-2 text-[12px] font-bold text-primary-foreground transition-all hover:bg-primary/90 active:scale-[0.98]"
+        @click="send(false)"
+      >
+        {{ $t('post.statusNotify.send') }}
+      </button>
+      <button
+        class="w-full whitespace-nowrap rounded-lg border border-border px-3 py-2 text-[12px] font-bold transition-colors hover:bg-secondary/50"
+        @click="composing = true"
+      >
+        {{ $t('post.statusNotify.customize') }}
+      </button>
+    </div>
+
+    <Dialog v-model:open="composing">
+      <DialogContent
+        :show-close-button="false"
+        class="!max-w-[560px] border border-border bg-card !rounded-[20px] !p-6 shadow-warm"
+      >
+        <DialogTitle class="sr-only">{{ $t('post.statusNotify.customize') }}</DialogTitle>
+        <DialogDescription class="sr-only">{{ $t('post.statusNotify.desc') }}</DialogDescription>
+
+        <div class="flex items-center gap-2.5">
+          <Avatar class="h-8 w-8">
+            <AvatarImage v-if="actorImage" :src="actorImage" :alt="actorName ?? ''" />
+            <AvatarFallback class="text-[12px] font-bold">{{ (actorName ?? '?').charAt(0).toUpperCase() }}</AvatarFallback>
+          </Avatar>
+          <span class="text-[15px] font-bold">{{ actorName }}</span>
+        </div>
+
+        <textarea
+          v-model="note"
+          rows="4"
+          maxlength="2000"
+          autofocus
+          class="w-full resize-none rounded-xl border border-border bg-background/50 px-4 py-3 text-[14px] focus-visible:border-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/10"
+          :placeholder="$t('post.statusNotify.messagePlaceholder')"
+        />
+
+        <div class="flex items-center justify-end gap-3">
+          <button
+            class="whitespace-nowrap rounded-xl border border-border px-4 py-2.5 text-[13px] font-bold transition-colors hover:bg-secondary/50"
+            @click="send(false)"
+          >
+            {{ $t('post.statusNotify.sendDefault') }}
+          </button>
+          <button
+            class="whitespace-nowrap rounded-xl bg-primary px-4 py-2.5 text-[13px] font-bold text-primary-foreground transition-all hover:bg-primary/90 active:scale-[0.98] disabled:opacity-50 disabled:active:scale-100"
+            :disabled="!note.trim()"
+            @click="send(true)"
+          >
+            {{ $t('post.statusNotify.sendCustom') }}
+          </button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  </div>
+</template>

--- a/app/components/roadmap/RoadmapKanban.vue
+++ b/app/components/roadmap/RoadmapKanban.vue
@@ -280,7 +280,9 @@ onUnmounted(() => {
 })
 
 // ---- Handle drop (pessimistic update) ----
-async function handleDrop(postId: string, fromStatus: RoadmapStatus, toStatus: RoadmapStatus) {
+// Dragging never notifies: it is a bulk triage gesture, so the status moves
+// silently. Mailing is done from the post detail sidebar.
+function handleDrop(postId: string, fromStatus: RoadmapStatus, toStatus: RoadmapStatus) {
   // Clear hover ghost immediately to avoid two ghosts in the same frame
   ghostPreview.value = null
   dropTargetStatus.value = null
@@ -295,21 +297,25 @@ async function handleDrop(postId: string, fromStatus: RoadmapStatus, toStatus: R
   const targetItems = roadmapData.value[toStatus].data
   const insertIndex = findInsertIndex(targetItems, item)
 
-  // Step 1: Source card stays but shows ghost state, target shows pending ghost
   pendingDrop.value = { postId, post: { ...item }, fromStatus, toStatus, index: insertIndex }
+  void writeDrop()
+}
 
-  // Step 2: Call API (with minimum display time for loading state)
+async function writeDrop() {
+  const drop = pendingDrop.value
+  if (!drop || !roadmapData.value) return
+  const { postId, post: item, fromStatus, toStatus } = drop
+
   const MIN_LOADING_MS = 400
   try {
     await Promise.all([
       useApiFetch(`/api/admin/posts/${postId}`, {
         method: 'PATCH',
-        body: { status: toStatus },
+        body: { status: toStatus, notify: false },
       }),
       new Promise(r => setTimeout(r, MIN_LOADING_MS)),
     ])
 
-    // Step 3a: Success — insert real card in target first, then clear pending + remove source
     // Insert before clearing pendingDrop so the key stays the same (pending → card, no animation)
     const toCol = roadmapData.value[toStatus]
     const realItem = { ...item, status: toStatus }
@@ -319,13 +325,14 @@ async function handleDrop(postId: string, fromStatus: RoadmapStatus, toStatus: R
     pendingDrop.value = null
 
     // Now remove source card (triggers leave animation in source column)
+    const fromCol = roadmapData.value[fromStatus]
     const sourceIdx = fromCol.data.findIndex(p => p.id === postId)
     if (sourceIdx !== -1) {
       fromCol.data.splice(sourceIdx, 1)
       fromCol.total--
     }
   } catch {
-    // Step 3b: Failure — just remove ghost, source card is still there
+    // Failure: drop the ghost; the source card never moved.
     pendingDrop.value = null
   }
 }

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -43,8 +43,7 @@ const navItems = [
 
 async function handleSignOut() {
   await signOut()
-  session.value = null
-  navigateTo(localePath('/'))
+  window.location.href = localePath('/')
 }
 
 // Mobile expandable nav

--- a/app/pages/dashboard/roadmap.vue
+++ b/app/pages/dashboard/roadmap.vue
@@ -34,7 +34,7 @@ async function handleCreated(slug: string) {
       if (post?.id) {
         await useApiFetch(`/api/admin/posts/${post.id}`, {
           method: 'PATCH',
-          body: { status: addStatus.value },
+          body: { status: addStatus.value, notify: false },
         })
       }
     } catch {

--- a/app/plugins/auth-reload.client.ts
+++ b/app/plugins/auth-reload.client.ts
@@ -1,0 +1,8 @@
+// Per-user state (vote highlight, subscription) sits in refs a soft session
+// refresh won't rebuild — hard-reload on account switch so it can't leak.
+export default defineNuxtPlugin(() => {
+  const { data: session } = useAuthSession()
+  watch(() => session.value?.user?.id, (id, prev) => {
+    if (id && id !== prev) reloadNuxtApp()
+  })
+})

--- a/app/stores/postDetail.ts
+++ b/app/stores/postDetail.ts
@@ -201,6 +201,7 @@ export const usePostDetailStore = defineStore('postDetail', () => {
       )
       p.voteCount = res.voteCount
       p.hasVoted = res.voted
+      p.subscribed = true // voting auto-subscribes on the backend
     } catch {
       p.hasVoted = false
       p.voteCount--
@@ -227,13 +228,18 @@ export const usePostDetailStore = defineStore('postDetail', () => {
     }
   }
 
-  async function addComment(slug: string, content: string, parentId?: string, replyToId?: string) {
+  async function addComment(
+    slug: string,
+    content: string,
+    opts: { parentId?: string; replyToId?: string; notify?: boolean } = {},
+  ) {
+    const { parentId, replyToId, notify } = opts
     const p = posts.value[slug]
     if (!p) return
 
     const res = await useApiFetch<CommentItem>(
       `/api/posts/${p.id}/comments`,
-      { method: 'POST', body: { content, parentId, replyToId } },
+      { method: 'POST', body: { content, parentId, replyToId, notifyVoters: notify } },
     )
 
     const list = commentsMap.value[p.id]

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -280,7 +280,26 @@
       "addPlaceholder": "Add a comment or feedback...",
       "viewMoreReplies": "View {count} more replies",
       "deleteTitle": "Delete this comment?",
-      "deleteDescription": "This action cannot be undone. This will permanently delete the comment and all its replies."
+      "deleteDescription": "This action cannot be undone. This will permanently delete the comment and all its replies.",
+      "notifyUpvoters": "Notify upvoters",
+      "notifyUpvotersHint": "Also email upvoters. The author and subscribers always get it.",
+      "emailUpvoters": "Email upvoters"
+    },
+    "statusNotify": {
+      "title": "Notify upvoters by email?",
+      "desc": "Send an automatic email update to notify upvoters about the status change.",
+      "customize": "Customize email",
+      "send": "Notify voters",
+      "dismiss": "Don't notify",
+      "messagePlaceholder": "Write a custom message for the upvoters…",
+      "sendDefault": "Send default email",
+      "sendCustom": "Send customized email"
+    },
+    "subscribe": {
+      "title": "Subscribe to post",
+      "desc": "Get notified by email when there are changes.",
+      "subscribe": "Subscribe",
+      "unsubscribe": "Unsubscribe"
     }
   },
   "auth": {

--- a/i18n/locales/zh.json
+++ b/i18n/locales/zh.json
@@ -280,7 +280,26 @@
       "addPlaceholder": "添加评论或反馈……",
       "viewMoreReplies": "查看另外 {count} 条回复",
       "deleteTitle": "删除这条评论?",
-      "deleteDescription": "此操作无法撤销,将永久删除该评论及其所有回复。"
+      "deleteDescription": "此操作无法撤销,将永久删除该评论及其所有回复。",
+      "notifyUpvoters": "通知点赞者",
+      "notifyUpvotersHint": "额外通知点赞过的人。作者和已订阅的人始终会收到。",
+      "emailUpvoters": "邮件通知点赞者"
+    },
+    "statusNotify": {
+      "title": "要给点赞者发邮件通知吗？",
+      "desc": "自动发一封邮件，告知点赞过这条反馈的人状态已变更。",
+      "customize": "自定义邮件",
+      "send": "通知点赞者",
+      "dismiss": "不通知",
+      "messagePlaceholder": "给点赞者写一段自定义消息…",
+      "sendDefault": "发送默认邮件",
+      "sendCustom": "发送自定义邮件"
+    },
+    "subscribe": {
+      "title": "订阅这条反馈",
+      "desc": "有变更时通过邮件通知你。",
+      "subscribe": "订阅",
+      "unsubscribe": "取消订阅"
     }
   },
   "auth": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -135,6 +135,9 @@ importers:
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@25.6.0)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
 
 packages:
 
@@ -2948,6 +2951,12 @@ packages:
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
   '@types/esrecurse@4.3.1':
     resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
 
@@ -3224,6 +3233,35 @@ packages:
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0
       vue: ^3.2.25
 
+  '@vitest/expect@4.1.10':
+    resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
+
+  '@vitest/mocker@4.1.10':
+    resolution: {integrity: sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.10':
+    resolution: {integrity: sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==}
+
+  '@vitest/runner@4.1.10':
+    resolution: {integrity: sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==}
+
+  '@vitest/snapshot@4.1.10':
+    resolution: {integrity: sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==}
+
+  '@vitest/spy@4.1.10':
+    resolution: {integrity: sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==}
+
+  '@vitest/utils@4.1.10':
+    resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
+
   '@volar/language-core@2.4.28':
     resolution: {integrity: sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==}
 
@@ -3422,6 +3460,10 @@ packages:
   aria-hidden@1.2.6:
     resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
     engines: {node: '>=10'}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   ast-kit@2.2.0:
     resolution: {integrity: sha512-m1Q/RaVOnTp9JxPX+F+Zn7IcLYMzM8kZofDImfsKZd8MbR+ikdOzTeztStWqfrqIxZnYWryyI9ePm3NGjnZgGw==}
@@ -3691,6 +3733,10 @@ packages:
 
   caniuse-lite@1.0.30001777:
     resolution: {integrity: sha512-tmN+fJxroPndC74efCdp12j+0rk0RHwV5Jwa1zWaFVyw2ZxAuPeG8ZgWC3Wz7uSjT3qMRQ5XHZ4COgQmsCMJAQ==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -4404,6 +4450,10 @@ packages:
   execa@9.6.1:
     resolution: {integrity: sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==}
     engines: {node: ^18.19.0 || >=20.5.0}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
 
   exsolve@1.0.8:
     resolution: {integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==}
@@ -6071,6 +6121,9 @@ packages:
     resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
@@ -6152,6 +6205,9 @@ packages:
     resolution: {integrity: sha512-o3yWv49B/o4QZk5ZcsALc6t0+eCelPc44zZsLtCQnZPDwFpDYSWcDnrv2TtMmMbQ7uKo3J0HTURCqckw23czNQ==}
     engines: {node: '>=12.0.0'}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   standard-as-callback@2.1.0:
     resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
 
@@ -6161,6 +6217,9 @@ packages:
 
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  std-env@4.2.0:
+    resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
 
   streamx@2.23.0:
     resolution: {integrity: sha512-kn+e44esVfn2Fa/O0CPFcex27fjIL6MkVae0Mm6q+E6f0hWv578YCERbv+4m02cjxvDsPKLnmxral/rR6lBMAg==}
@@ -6294,6 +6353,9 @@ packages:
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
   tinyexec@1.0.2:
     resolution: {integrity: sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==}
     engines: {node: '>=18'}
@@ -6301,6 +6363,10 @@ packages:
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -6690,6 +6756,47 @@ packages:
       yaml:
         optional: true
 
+  vitest@4.1.10:
+    resolution: {integrity: sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.10
+      '@vitest/browser-preview': 4.1.10
+      '@vitest/browser-webdriverio': 4.1.10
+      '@vitest/coverage-istanbul': 4.1.10
+      '@vitest/coverage-v8': 4.1.10
+      '@vitest/ui': 4.1.10
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   vscode-uri@3.1.0:
     resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
 
@@ -6800,6 +6907,11 @@ packages:
   which@5.0.0:
     resolution: {integrity: sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==}
     engines: {node: ^18.17.0 || >=20.5.0}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   word-wrap@1.2.5:
@@ -9898,6 +10010,13 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
   '@types/esrecurse@4.3.1': {}
 
   '@types/estree@1.0.8': {}
@@ -10183,6 +10302,47 @@ snapshots:
       vite: 7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
       vue: 3.5.30(typescript@5.9.3)
 
+  '@vitest/expect@4.1.10':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.10(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
+    dependencies:
+      '@vitest/spy': 4.1.10
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+
+  '@vitest/pretty-format@4.1.10':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.10':
+    dependencies:
+      '@vitest/utils': 4.1.10
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/utils': 4.1.10
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.10': {}
+
+  '@vitest/utils@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
   '@volar/language-core@2.4.28':
     dependencies:
       '@volar/source-map': 2.4.28
@@ -10461,6 +10621,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  assertion-error@2.0.1: {}
+
   ast-kit@2.2.0:
     dependencies:
       '@babel/parser': 7.29.0
@@ -10693,6 +10855,8 @@ snapshots:
       lodash.uniq: 4.5.0
 
   caniuse-lite@1.0.30001777: {}
+
+  chai@6.2.2: {}
 
   chalk@4.1.2:
     dependencies:
@@ -11420,6 +11584,8 @@ snapshots:
       signal-exit: 4.1.0
       strip-final-newline: 4.0.0
       yoctocolors: 2.1.2
+
+  expect-type@1.4.0: {}
 
   exsolve@1.0.8: {}
 
@@ -13512,6 +13678,8 @@ snapshots:
 
   shell-quote@1.8.3: {}
 
+  siginfo@2.0.0: {}
+
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
@@ -13577,11 +13745,15 @@ snapshots:
 
   stable-hash-x@0.2.0: {}
 
+  stackback@0.0.2: {}
+
   standard-as-callback@2.1.0: {}
 
   statuses@2.0.2: {}
 
   std-env@3.10.0: {}
+
+  std-env@4.2.0: {}
 
   streamx@2.23.0:
     dependencies:
@@ -13725,12 +13897,16 @@ snapshots:
 
   tiny-invariant@1.3.3: {}
 
+  tinybench@2.9.0: {}
+
   tinyexec@1.0.2: {}
 
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
+
+  tinyrainbow@3.1.0: {}
 
   to-regex-range@5.0.1:
     dependencies:
@@ -14107,6 +14283,33 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.8.2
 
+  vitest@4.1.10(@types/node@25.6.0)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.0.0
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.2
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.1.0
+      vite: 7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.6.0
+    transitivePeerDependencies:
+      - msw
+
   vscode-uri@3.1.0: {}
 
   vue-bundle-renderer@2.2.0:
@@ -14216,6 +14419,11 @@ snapshots:
   which@5.0.0:
     dependencies:
       isexe: 3.1.5
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   word-wrap@1.2.5: {}
 

--- a/server/api/admin/posts/[id].patch.ts
+++ b/server/api/admin/posts/[id].patch.ts
@@ -9,12 +9,12 @@ export default defineEventHandler(async (event) => {
   const id = getRouterParam(event, 'id')!
   const body = await readValidatedBody(event, updatePostSchema.parse)
 
-  const { orgId } = await requireOrgPermission(event, { feedlog: ['moderate'] })
+  const { session, orgId } = await requireOrgPermission(event, { feedlog: ['moderate'] })
 
   const db = useDB()
 
   const [existing] = await db
-    .select({ id: post.id, title: post.title, content: post.content })
+    .select({ id: post.id, title: post.title, content: post.content, status: post.status })
     .from(post)
     .where(and(eq(post.id, id), eq(post.orgId, orgId)))
     .limit(1)
@@ -67,5 +67,7 @@ export default defineEventHandler(async (event) => {
     )
   }
 
+  // Status changes are silent here — notifications go through the separate
+  // POST /api/admin/posts/:id/notify-status, decided by the admin after the fact.
   return updated
 })

--- a/server/api/admin/posts/[id]/notify-status.post.ts
+++ b/server/api/admin/posts/[id]/notify-status.post.ts
@@ -1,0 +1,49 @@
+import { z } from 'zod'
+import { and, eq } from 'drizzle-orm'
+import { getRequestURL } from 'h3'
+import { post } from '#layers/feedlog/server/db/schemas'
+import { resolvePostThreadRecipients, resolveOrgSlug, deliverToRecipients } from '#layers/feedlog/server/utils/notifications'
+import { POST_STATUSES } from '#layers/feedlog/shared/types/post'
+
+// POST /api/admin/posts/:id/notify-status — mail the post's subscribers that it
+// is now in status X. The status is already written by PATCH; this only sends.
+const bodySchema = z.object({
+  status: z.enum(POST_STATUSES as unknown as [string, ...string[]]),
+  note: z.string().trim().max(2000).optional(),
+})
+
+export default defineEventHandler(async (event) => {
+  const id = getRouterParam(event, 'id')!
+  const body = await readValidatedBody(event, bodySchema.parse)
+  const { session, orgId } = await requireOrgPermission(event, { feedlog: ['moderate'] })
+
+  const db = useDB()
+  const [existing] = await db
+    .select({ id: post.id, status: post.status })
+    .from(post)
+    .where(and(eq(post.id, id), eq(post.orgId, orgId)))
+    .limit(1)
+
+  if (!existing) {
+    throw createError({ statusCode: 404, message: 'Post not found' })
+  }
+  // Optimistic lock: the admin acts on the status they saw on the card. If it
+  // changed under them, refuse rather than announce a status they never saw.
+  if (existing.status !== body.status) {
+    throw createError({ statusCode: 409, message: 'Status was changed by someone else' })
+  }
+
+  // Resolve recipients synchronously so we can return the count; send async.
+  const orgSlug = await resolveOrgSlug(orgId)
+  const recipients = orgSlug ? await resolvePostThreadRecipients(orgId, id, session.user.id) : []
+
+  if (recipients.length > 0) {
+    event.waitUntil(
+      deliverToRecipients(orgId, orgSlug, recipients, 'post.status_changed',
+        { to: body.status, note: body.note || undefined }, getRequestURL(event).origin)
+        .catch((err: unknown) => console.error('[notifications] status notify failed', err)),
+    )
+  }
+
+  return { ok: true, recipients: recipients.length }
+})

--- a/server/api/auth/set-password.post.ts
+++ b/server/api/auth/set-password.post.ts
@@ -17,7 +17,6 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 400, message: 'Password must be at most 128 characters' })
   }
 
-  // Check if user already has a credential account
   const accounts = await auth.api.listUserAccounts({ headers: getHeaders(event) })
   const hasCredential = accounts?.some(
     (acc: { providerId: string }) => acc.providerId === 'credential',
@@ -26,7 +25,6 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 400, message: 'Password already set. Use change-password instead.' })
   }
 
-  // Use better-auth's internal setPassword endpoint
   const result = await auth.api.setPassword({
     body: { newPassword: body.newPassword },
     headers: getHeaders(event),

--- a/server/api/posts/[postId]/comments/index.post.ts
+++ b/server/api/posts/[postId]/comments/index.post.ts
@@ -1,11 +1,15 @@
 import { and, eq, sql } from 'drizzle-orm'
+import { getRequestURL } from 'h3'
 import { z } from 'zod/v4'
 import { comment, post, user } from '#layers/feedlog/server/db/schemas'
+import { isActorAdmin } from '#layers/feedlog/shared/utils/notifications'
 
 const createCommentSchema = z.object({
   content: z.string().trim().min(1, 'Content is required').max(5000, 'Comment must be 5000 characters or less'),
   parentId: z.uuid().optional(),
   replyToId: z.uuid().optional(),
+  // Admin opt-out for pinging upvoters; author + manual subscribers always get it.
+  notifyVoters: z.boolean().optional(),
 })
 
 // POST /api/posts/:postId/comments — Create a comment (any authenticated user).
@@ -68,6 +72,22 @@ export default defineEventHandler(async (event) => {
     await db.update(comment).set({ replyCount: sql`${comment.replyCount} + 1` }).where(eq(comment.id, parentId))
   }
   await db.update(post).set({ commentCount: sql`${post.commentCount} + 1` }).where(eq(post.id, postId))
+
+  // Best-effort, after the write. Only an admin's top-level comment notifies
+  // (resolveCommentEvents no-ops for replies / non-admins). Author + manual
+  // subscribers always get it; upvoters only when notifyVoters isn't false.
+  event.waitUntil(
+    emitCommentNotifications({
+      orgId,
+      postId,
+      snippet: body.content,
+      actorId: session.user.id,
+      authorIsAdmin: isActorAdmin(session, orgId),
+      isTopLevel: !parentId,
+      notifyVoters: body.notifyVoters !== false,
+      requestOrigin: getRequestURL(event).origin,
+    }).catch((err: unknown) => console.error('[notifications] comment emit failed', err)),
+  )
 
   // Fetch author info
   const [author] = await db

--- a/server/api/posts/[postId]/index.get.ts
+++ b/server/api/posts/[postId]/index.get.ts
@@ -62,6 +62,23 @@ export default defineEventHandler(async (event): Promise<PostDetail> => {
     }
   }
 
+  // subscribed: is the current user on this post's notification list, across
+  // the whole merge family. Drives the sidebar subscribe card's button state.
+  let subscribed = false
+  if (session) {
+    const [result] = await db.execute(sql`
+      WITH RECURSIVE family AS (
+        SELECT id FROM post WHERE id = ${row.id}
+        UNION ALL
+        SELECT p.id FROM post p JOIN family f ON p.merged_to = f.id
+      )
+      SELECT EXISTS(
+        SELECT 1 FROM post_subscription WHERE user_id = ${session.user.id} AND post_id IN (SELECT id FROM family)
+      ) as subscribed
+    `)
+    subscribed = !!(result as any)?.subscribed
+  }
+
   // If merged, fetch canonical post info
   let canonicalPost: { slug: string; title: string } | undefined
   if (row.mergedTo) {
@@ -85,6 +102,7 @@ export default defineEventHandler(async (event): Promise<PostDetail> => {
     mergedTo: row.mergedTo,
     mergedCount: row.mergedCount,
     hasVoted,
+    subscribed,
     author: { id: row.authorId, name: row.authorName, image: row.authorImage },
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,

--- a/server/api/posts/[postId]/subscription.delete.ts
+++ b/server/api/posts/[postId]/subscription.delete.ts
@@ -1,0 +1,21 @@
+import { and, eq } from 'drizzle-orm'
+import { post, postSubscription } from '#layers/feedlog/server/db/schemas'
+
+// DELETE /api/posts/:postId/subscription — unsubscribe. Removes the row.
+// Idempotent: deleting a non-existent row is a no-op.
+export default defineEventHandler(async (event) => {
+  const { session, orgId } = await requireAuthInOrg(event)
+  const postId = getRouterParam(event, 'postId')!
+  const db = useDB()
+
+  const [p] = await db.select({ id: post.id }).from(post)
+    .where(and(eq(post.id, postId), eq(post.orgId, orgId))).limit(1)
+  if (!p) {
+    throw createError({ statusCode: 404, message: 'Post not found' })
+  }
+
+  await db.delete(postSubscription)
+    .where(and(eq(postSubscription.postId, postId), eq(postSubscription.userId, session.user.id)))
+
+  return { subscribed: false }
+})

--- a/server/api/posts/[postId]/subscription.post.ts
+++ b/server/api/posts/[postId]/subscription.post.ts
@@ -1,0 +1,27 @@
+import { and, eq } from 'drizzle-orm'
+import { post, postSubscription } from '#layers/feedlog/server/db/schemas'
+import { isActorAdmin } from '#layers/feedlog/shared/utils/notifications'
+
+// POST /api/posts/:postId/subscription — subscribe to this post. A row means
+// subscribed. Idempotent. Admins are refused: they don't receive post-thread
+// mail, so a row would only become dead data skipped at send time.
+export default defineEventHandler(async (event) => {
+  const { session, orgId } = await requireAuthInOrg(event)
+  const postId = getRouterParam(event, 'postId')!
+  const db = useDB()
+
+  const [p] = await db.select({ id: post.id }).from(post)
+    .where(and(eq(post.id, postId), eq(post.orgId, orgId))).limit(1)
+  if (!p) {
+    throw createError({ statusCode: 404, message: 'Post not found' })
+  }
+  if (isActorAdmin(session, orgId)) {
+    throw createError({ statusCode: 403, message: 'Admins do not subscribe to posts' })
+  }
+
+  await db.insert(postSubscription)
+    .values({ postId, userId: session.user.id })
+    .onConflictDoNothing()
+
+  return { subscribed: true }
+})

--- a/server/api/posts/[postId]/vote.post.ts
+++ b/server/api/posts/[postId]/vote.post.ts
@@ -1,5 +1,6 @@
 import { eq, and, sql } from 'drizzle-orm'
-import { vote, post } from '#layers/feedlog/server/db/schemas'
+import { vote, post, postSubscription } from '#layers/feedlog/server/db/schemas'
+import { isActorAdmin } from '#layers/feedlog/shared/utils/notifications'
 
 // POST /api/posts/:id/vote — Vote on a post (any authenticated user, idempotent).
 export default defineEventHandler(async (event) => {
@@ -41,6 +42,12 @@ export default defineEventHandler(async (event) => {
     .set({ voteCount: sql`${post.voteCount} + 1` })
     .where(eq(post.id, postId))
     .returning({ voteCount: post.voteCount })
+
+  // Voting subscribes you to the post — unless you're an admin (admins don't
+  // receive post-thread mail). Un-voting does NOT unsubscribe.
+  if (!isActorAdmin(session, orgId)) {
+    await db.insert(postSubscription).values({ postId, userId: session.user.id }).onConflictDoNothing()
+  }
 
   return { voted: true, voteCount: updated?.voteCount ?? 0 }
 })

--- a/server/api/posts/index.post.ts
+++ b/server/api/posts/index.post.ts
@@ -1,6 +1,7 @@
-import { post, postSearch, user } from '#layers/feedlog/server/db/schemas'
+import { post, postSearch, user, postSubscription } from '#layers/feedlog/server/db/schemas'
 import { eq } from 'drizzle-orm'
 import { createPostSchema } from '#layers/feedlog/shared/schemas/post'
+import { isActorAdmin } from '#layers/feedlog/shared/utils/notifications'
 
 // POST /api/posts — Create a post (any authenticated user: end-user or staff).
 export default defineEventHandler(async (event) => {
@@ -36,6 +37,11 @@ export default defineEventHandler(async (event) => {
   await db
     .insert(postSearch)
     .values({ postId: created.id, orgId, searchText })
+
+  // The author subscribes to their own post — unless they're an admin.
+  if (!isActorAdmin(session, orgId)) {
+    await db.insert(postSubscription).values({ postId: created.id, userId: session.user.id }).onConflictDoNothing()
+  }
 
   // Async embedding generation (non-blocking)
   event.waitUntil(

--- a/server/db/migrations/0006_puzzling_mantis.sql
+++ b/server/db/migrations/0006_puzzling_mantis.sql
@@ -1,0 +1,28 @@
+CREATE TABLE "post_subscription" (
+	"post_id" uuid NOT NULL,
+	"user_id" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "post_subscription_post_id_user_id_pk" PRIMARY KEY("post_id","user_id")
+);
+--> statement-breakpoint
+-- Backfill: authors subscribe to their own posts (skip org admins).
+INSERT INTO "post_subscription" ("post_id", "user_id")
+SELECT p.id, p.author_id
+FROM "post" p
+WHERE NOT EXISTS (
+	SELECT 1 FROM "member" m
+	WHERE m.user_id = p.author_id AND m.organization_id = p.org_id
+		AND m.role IN ('owner', 'manager')
+)
+ON CONFLICT DO NOTHING;--> statement-breakpoint
+-- Backfill: voters subscribe to posts they upvoted (skip org admins).
+INSERT INTO "post_subscription" ("post_id", "user_id")
+SELECT v.post_id, v.user_id
+FROM "vote" v
+JOIN "post" p ON p.id = v.post_id
+WHERE NOT EXISTS (
+	SELECT 1 FROM "member" m
+	WHERE m.user_id = v.user_id AND m.organization_id = p.org_id
+		AND m.role IN ('owner', 'manager')
+)
+ON CONFLICT DO NOTHING;

--- a/server/db/migrations/meta/0006_snapshot.json
+++ b/server/db/migrations/meta/0006_snapshot.json
@@ -1,0 +1,1930 @@
+{
+  "id": "b936a6d7-1b33-45f4-928b-24110925b1c0",
+  "prevId": "bbad398d-7575-47bd-849b-6bb9c2d3c2c4",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board": {
+      "name": "board",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_board_org_position": {
+          "name": "idx_board_org_position",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.changelog": {
+      "name": "changelog",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(300)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(70)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "categories": {
+          "name": "categories",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "cover": {
+          "name": "cover",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_title": {
+          "name": "published_title",
+          "type": "varchar(70)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_content": {
+          "name": "published_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_categories": {
+          "name": "published_categories",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_cover": {
+          "name": "published_cover",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_changelog_org_public": {
+          "name": "idx_changelog_org_public",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"published_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"changelog\".\"published_at\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_changelog_org_admin": {
+          "name": "idx_changelog_org_admin",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"updated_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_changelog_org_slug": {
+          "name": "idx_changelog_org_slug",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_changelog_title_trgm": {
+          "name": "idx_changelog_title_trgm",
+          "columns": [
+            {
+              "expression": "\"title\" gist_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gist",
+          "with": {}
+        },
+        "idx_changelog_content_trgm": {
+          "name": "idx_changelog_content_trgm",
+          "columns": [
+            {
+              "expression": "\"content\" gist_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gist",
+          "with": {}
+        },
+        "idx_changelog_pub_title_trgm": {
+          "name": "idx_changelog_pub_title_trgm",
+          "columns": [
+            {
+              "expression": "\"published_title\" gist_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gist",
+          "with": {}
+        },
+        "idx_changelog_pub_content_trgm": {
+          "name": "idx_changelog_pub_content_trgm",
+          "columns": [
+            {
+              "expression": "\"published_content\" gist_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gist",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.changelog_reaction": {
+      "name": "changelog_reaction",
+      "schema": "",
+      "columns": {
+        "changelog_id": {
+          "name": "changelog_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "changelog_reaction_changelog_id_user_id_emoji_pk": {
+          "name": "changelog_reaction_changelog_id_user_id_emoji_pk",
+          "columns": [
+            "changelog_id",
+            "user_id",
+            "emoji"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comment": {
+      "name": "comment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_to_id": {
+          "name": "reply_to_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_count": {
+          "name": "reply_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "like_count": {
+          "name": "like_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'comment'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edited_at": {
+          "name": "edited_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_comment_top_level": {
+          "name": "idx_comment_top_level",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"comment\".\"parent_id\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_comment_top_likes": {
+          "name": "idx_comment_top_likes",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"like_count\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"comment\".\"parent_id\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_comment_children": {
+          "name": "idx_comment_children",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"comment\".\"parent_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comment_like": {
+      "name": "comment_like",
+      "schema": "",
+      "columns": {
+        "comment_id": {
+          "name": "comment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "comment_like_comment_id_user_id_pk": {
+          "name": "comment_like_comment_id_user_id_pk",
+          "columns": [
+            "comment_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invitation_org_idx": {
+          "name": "invitation_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitation_email_idx": {
+          "name": "invitation_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member": {
+      "name": "member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "member_userId_idx": {
+          "name": "member_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_org_user_unique": {
+          "name": "member_org_user_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_sso": {
+      "name": "organization_sso",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_organization_sso_org": {
+          "name": "idx_organization_sso_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_sso_org_id_organization_id_fk": {
+          "name": "organization_sso_org_id_organization_id_fk",
+          "tableFrom": "organization_sso",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post": {
+      "name": "post",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(300)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "excerpt": {
+          "name": "excerpt",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote_count": {
+          "name": "vote_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "comment_count": {
+          "name": "comment_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "merged_to": {
+          "name": "merged_to",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_post_org_created": {
+          "name": "idx_post_org_created",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_post_org_votes": {
+          "name": "idx_post_org_votes",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"vote_count\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_post_org_board_created": {
+          "name": "idx_post_org_board_created",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_post_org_board_votes": {
+          "name": "idx_post_org_board_votes",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"vote_count\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_post_org_board_status": {
+          "name": "idx_post_org_board_status",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_post_org_status_votes": {
+          "name": "idx_post_org_status_votes",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"vote_count\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_post_org_slug": {
+          "name": "idx_post_org_slug",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_post_merged_to": {
+          "name": "idx_post_merged_to",
+          "columns": [
+            {
+              "expression": "merged_to",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"post\".\"merged_to\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_embedding": {
+      "name": "post_embedding",
+      "schema": "",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(768)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_post_embedding_org": {
+          "name": "idx_post_embedding_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "post_embedding_post_id_post_id_fk": {
+          "name": "post_embedding_post_id_post_id_fk",
+          "tableFrom": "post_embedding",
+          "tableTo": "post",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_search": {
+      "name": "post_search",
+      "schema": "",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "search_text": {
+          "name": "search_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_post_search_org": {
+          "name": "idx_post_search_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "post_search_post_id_post_id_fk": {
+          "name": "post_search_post_id_post_id_fk",
+          "tableFrom": "post_search",
+          "tableTo": "post",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_subscription": {
+      "name": "post_subscription",
+      "schema": "",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "post_subscription_post_id_user_id_pk": {
+          "name": "post_subscription_post_id_user_id_pk",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sso_org_id": {
+          "name": "sso_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vote": {
+      "name": "vote",
+      "schema": "",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "vote_post_id_user_id_pk": {
+          "name": "vote_post_id_user_id_pk",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/server/db/migrations/meta/_journal.json
+++ b/server/db/migrations/meta/_journal.json
@@ -1,48 +1,55 @@
 {
-  "version": "7",
-  "dialect": "postgresql",
-  "entries": [
-    {
-      "idx": 0,
-      "version": "7",
-      "when": 1773653078089,
-      "tag": "0000_perpetual_moonstone",
-      "breakpoints": true
-    },
-    {
-      "idx": 1,
-      "version": "7",
-      "when": 1775182014664,
-      "tag": "0001_open_lorna_dane",
-      "breakpoints": true
-    },
-    {
-      "idx": 2,
-      "version": "7",
-      "when": 1775800650384,
-      "tag": "0002_yellow_spectrum",
-      "breakpoints": true
-    },
-    {
-      "idx": 3,
-      "version": "7",
-      "when": 1777056000000,
-      "tag": "0003_seed_defaults",
-      "breakpoints": true
-    },
-    {
-      "idx": 4,
-      "version": "7",
-      "when": 1779580800000,
-      "tag": "0004_member_management",
-      "breakpoints": true
-    },
-    {
-      "idx": 5,
-      "version": "7",
-      "when": 1779947828444,
-      "tag": "0005_silky_silver_fox",
-      "breakpoints": true
-    }
-  ]
+	"version": "7",
+	"dialect": "postgresql",
+	"entries": [
+		{
+			"idx": 0,
+			"version": "7",
+			"when": 1773653078089,
+			"tag": "0000_perpetual_moonstone",
+			"breakpoints": true
+		},
+		{
+			"idx": 1,
+			"version": "7",
+			"when": 1775182014664,
+			"tag": "0001_open_lorna_dane",
+			"breakpoints": true
+		},
+		{
+			"idx": 2,
+			"version": "7",
+			"when": 1775800650384,
+			"tag": "0002_yellow_spectrum",
+			"breakpoints": true
+		},
+		{
+			"idx": 3,
+			"version": "7",
+			"when": 1777056000000,
+			"tag": "0003_seed_defaults",
+			"breakpoints": true
+		},
+		{
+			"idx": 4,
+			"version": "7",
+			"when": 1779580800000,
+			"tag": "0004_member_management",
+			"breakpoints": true
+		},
+		{
+			"idx": 5,
+			"version": "7",
+			"when": 1779947828444,
+			"tag": "0005_silky_silver_fox",
+			"breakpoints": true
+		},
+		{
+			"idx": 6,
+			"version": "7",
+			"when": 1784515259375,
+			"tag": "0006_puzzling_mantis",
+			"breakpoints": true
+		}
+	]
 }

--- a/server/db/schemas/index.ts
+++ b/server/db/schemas/index.ts
@@ -21,6 +21,10 @@ export {
   organizationSso,
   organizationSsoRelations,
 } from './sso'
+export {
+  postSubscription,
+} from './notifications'
+export type { NotificationPayload } from './notifications'
 import { user, session, account, organization, member, invitation } from './auth'
 
 // Custom type for pgvector's vector column

--- a/server/db/schemas/notifications.ts
+++ b/server/db/schemas/notifications.ts
@@ -1,0 +1,24 @@
+import { pgTable, uuid, text, timestamp, primaryKey } from 'drizzle-orm/pg-core'
+
+// Notification system storage — one LAYER-owned table (post_subscription).
+
+// The in-memory payload handed to the email renderer (never stored).
+export interface NotificationPayload {
+  to?: string // status_changed: the new status
+  note?: string // admin's optional note carried with a status change
+  snippet?: string // comment excerpt for the email body
+  actorName?: string // admin_replied: who replied (shown in the email)
+  actorImage?: string | null // admin_replied: their avatar
+}
+
+// Who is subscribed to which post. A row = subscribed; no row = not. Authorship
+// and votes insert a row (unless the actor is an org admin); the subscribe card
+// and the DELETE endpoint add/remove rows. Recipient resolution reads this table
+// directly across the merge family.
+export const postSubscription = pgTable('post_subscription', {
+  postId: uuid('post_id').notNull(),
+  userId: text('user_id').notNull(),
+  createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+}, (t) => [
+  primaryKey({ columns: [t.postId, t.userId] }),
+])

--- a/server/plugins/email.ts
+++ b/server/plugins/email.ts
@@ -16,11 +16,11 @@ export default defineNitroPlugin(() => {
 
     registerEmailProvider({
       name: 'resend',
-      send: async ({ to, subject, html, text }) => {
+      send: async ({ to, subject, html, text, headers }) => {
         const response = await $fetch<{ id: string }>('https://api.resend.com/emails', {
           method: 'POST',
           headers: { Authorization: `Bearer ${resendApiKey}` },
-          body: { from, to, subject, html, text },
+          body: { from, to, subject, html, text, headers },
           timeout: 10_000,
           retry: 0,
         })

--- a/server/utils/email-templates.ts
+++ b/server/utils/email-templates.ts
@@ -1,5 +1,6 @@
 // Email HTML templates — auto-imported by Nitro.
 // Brand primary color matches public/logo.svg.
+import { STATUS_CONFIG } from '../../shared/types/post'
 
 const BRAND_COLOR = '#C45A46'
 const FONT_STACK = `-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif`
@@ -53,7 +54,7 @@ export function renderVerificationEmail({ url, name }: { url: string; name: stri
     preheader: 'One click to activate · link expires in 1 hour.',
     content: `
 <h2 style="margin: 0 0 16px; font-size: 20px; font-weight: 600;">Confirm your email to get started</h2>
-<p style="margin: 0 0 12px;">Hi ${name},</p>
+<p style="margin: 0 0 12px;">Hi ${escapeHtml(name)},</p>
 <p style="margin: 0 0 12px;">Confirm your email to activate your FeedLog account and start:</p>
 <ul style="margin: 0 0 24px; padding-left: 20px; color: #374151;">
   <li style="margin-bottom: 4px;">Voting on features you care about</li>
@@ -62,16 +63,16 @@ export function renderVerificationEmail({ url, name }: { url: string; name: stri
 </ul>
 ${actionButton(url, 'Confirm Email')}
 ${fallbackLink(url)}
-${expiryNote("This link expires in 1 hour. If you didn't sign up for FeedLog, you can safely ignore this email.")}
+${expiryNote('This link expires in 1 hour. If you didn\'t sign up for FeedLog, you can safely ignore this email.')}
 `,
   })
 }
 
 export function renderInvitationEmail({ url, orgName }: { url: string; orgName: string }): string {
   return layout({
-    preheader: `You're invited to join ${orgName} on FeedLog.`,
+    preheader: `You're invited to join ${escapeHtml(orgName)} on FeedLog.`,
     content: `
-<h2 style="margin: 0 0 16px; font-size: 20px; font-weight: 600;">Join ${orgName} on FeedLog</h2>
+<h2 style="margin: 0 0 16px; font-size: 20px; font-weight: 600;">Join ${escapeHtml(orgName)} on FeedLog</h2>
 <p style="margin: 0 0 12px;">You've been invited to collaborate. Click below to accept and get started:</p>
 ${actionButton(url, 'Accept invitation')}
 ${fallbackLink(url)}
@@ -82,10 +83,10 @@ ${expiryNote('This invitation link is tied to your email. If you weren\'t expect
 
 export function renderResetPasswordEmail({ url, name }: { url: string; name: string }): string {
   return layout({
-    preheader: "A password reset was requested for your account. If it wasn't you, ignore this email.",
+    preheader: 'A password reset was requested for your account. If it wasn\'t you, ignore this email.',
     content: `
 <h2 style="margin: 0 0 16px; font-size: 20px; font-weight: 600;">Reset your password</h2>
-<p style="margin: 0 0 12px;">Hi ${name},</p>
+<p style="margin: 0 0 12px;">Hi ${escapeHtml(name)},</p>
 <p style="margin: 0 0 24px;">Someone requested a password reset for your FeedLog account. If this was you, click the button below to set a new password:</p>
 ${actionButton(url, 'Reset Password')}
 ${fallbackLink(url)}
@@ -99,13 +100,133 @@ ${expiryNote('This link expires in 1 hour and can only be used once.')}
 }
 
 export function renderPasswordSetEmail({ name }: { name: string }): string {
+  const contact = `<a href="mailto:feedlog.oss@outlook.com" style="color: ${BRAND_COLOR}; text-decoration: underline;">feedlog.oss@outlook.com</a>`
   return layout({
-    preheader: "If this wasn't you, reset your password immediately.",
+    preheader: 'If this wasn\'t you, reset your password immediately.',
     content: `
 <h2 style="margin: 0 0 16px; font-size: 20px; font-weight: 600;">A password was added to your account</h2>
-<p style="margin: 0 0 16px;">Hi ${name},</p>
+<p style="margin: 0 0 16px;">Hi ${escapeHtml(name)},</p>
 <p style="margin: 0 0 16px;">A password was just added to your FeedLog account. You can now sign in with email and password in addition to your social login.</p>
-<p style="margin: 0 0 24px; color: #374151;">If this wasn't you, reset your password right away and contact <a href="mailto:feedlog.oss@outlook.com" style="color: ${BRAND_COLOR}; text-decoration: underline;">feedlog.oss@outlook.com</a>.</p>
+<p style="margin: 0 0 24px; color: #374151;">If this wasn't you, reset your password right away and contact ${contact}.</p>
 `,
   })
+}
+
+// --- Notification templates (English only, Featurebase-style) ---
+
+// User-authored text (titles, notes, comment snippets) enters the HTML body
+// here, so every interpolation is escaped.
+function escapeHtml(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#39;')
+}
+
+export interface NotificationEmailContent {
+  subject: string
+  html: string
+  text: string
+}
+
+const FOOTER_REASON = 'You\'re receiving this because of your activity on this FeedLog board.'
+
+// Gray page → centered FeedLog wordmark → white rounded card → centered footer.
+// No links in the footer; the physical postal address (CAN-SPAM) is a pre-launch
+// item, not fabricated here.
+function notificationShell(cardInner: string, preheader: string): string {
+  return `
+<div style="background: #f6f7fb; padding: 40px 16px; font-family: ${FONT_STACK};">
+  <div style="display: none; max-height: 0; overflow: hidden; mso-hide: all;">${escapeHtml(preheader)}</div>
+  <div style="max-width: 560px; margin: 0 auto;">
+    <div style="text-align: center; padding-bottom: 28px;">
+      <span style="font-size: 22px; font-weight: 800; color: ${BRAND_COLOR}; letter-spacing: -0.02em;">FeedLog</span>
+    </div>
+    <div style="background: #fff; border: 1px solid #eceef3; border-radius: 16px; padding: 40px 36px;">
+${cardInner}
+    </div>
+    <div style="text-align: center; padding: 24px 8px 0; color: #9ca3af; font-size: 12px; line-height: 1.6;">
+      <p style="margin: 0;">${FOOTER_REASON}</p>
+    </div>
+  </div>
+</div>`
+}
+
+function pillButton(url: string, label: string): string {
+  return `<div style="text-align: center; margin-top: 32px;"><a href="${url}" style="display: inline-block; padding: 14px 40px; background: ${BRAND_COLOR}; color: #fff; text-decoration: none; border-radius: 999px; font-weight: 700; font-size: 16px;">${label}</a></div>`
+}
+
+function statusChangeCard(title: string, to: string, note?: string): NotificationEmailContent {
+  const cfg = STATUS_CONFIG[to as keyof typeof STATUS_CONFIG] ?? STATUS_CONFIG.open
+  const label = cfg.label
+  const noteHtml = note
+    ? `<p style="margin: 20px 0 0; text-align: center; font-size: 15px; color: #6b7280; line-height: 1.7;">${escapeHtml(note)}</p>`
+    : ''
+  const inner = `
+      <p style="margin: 0; text-align: center; font-size: 20px; line-height: 1.5; color: #1f2937;">
+        A post you upvoted, <strong style="color: #111827;">${escapeHtml(title)}</strong>, has been changed to <span style="color: ${cfg.color}; font-weight: 700;">${label}</span>
+      </p>${noteHtml}
+      ${pillButton('{{postUrl}}', 'View post')}`
+  return {
+    subject: `${label} - "${title}"`,
+    html: inner,
+    text: `A post you upvoted, ${title}, has been changed to ${label}.${note ? `\n\n${note}` : ''}`,
+  }
+}
+
+function adminReplyCard(title: string, actorName: string, actorImage: string | null | undefined, snippet: string): NotificationEmailContent {
+  const initial = (actorName || '?').charAt(0).toUpperCase()
+  // Only trust an http(s) URL as a src; anything else falls back to the initial avatar.
+  const safeImage = actorImage && /^https?:\/\//i.test(actorImage) ? actorImage : null
+  const avatar = safeImage
+    ? `<img src="${escapeHtml(safeImage)}" width="40" height="40" style="border-radius: 999px; display: block;" alt="">`
+    : `<div style="width: 40px; height: 40px; border-radius: 999px; background: ${BRAND_COLOR}; color: #fff; font-size: 16px; font-weight: 700; text-align: center; line-height: 40px;">${escapeHtml(initial)}</div>`
+  const inner = `
+      <p style="margin: 0 0 20px; font-size: 17px; font-weight: 700; color: #111827; line-height: 1.4;">${escapeHtml(title)}</p>
+      <table cellpadding="0" cellspacing="0" style="width: 100%;"><tr>
+        <td width="48" valign="top">${avatar}</td>
+        <td valign="top" style="padding-left: 4px;">
+          <div style="font-size: 16px; font-weight: 700; color: #111827; margin-bottom: 4px;">${escapeHtml(actorName)}</div>
+          <div style="font-size: 15px; color: #6b7280; line-height: 1.7;">${escapeHtml(snippet)}</div>
+        </td>
+      </tr></table>
+      ${pillButton('{{postUrl}}', 'View comment')}`
+  return {
+    subject: `New comment for "${title}"`,
+    html: inner,
+    text: `${actorName} commented on "${title}":\n\n${snippet}`,
+  }
+}
+
+// Dispatch a notification to its template. Returns null for an unknown type so
+// the caller logs it rather than sending a blank email.
+export function renderNotificationEmail(input: {
+  typeKey: string
+  postTitle?: string
+  postUrl: string
+  to?: string
+  note?: string
+  snippet?: string
+  actorName?: string
+  actorImage?: string | null
+}): NotificationEmailContent | null {
+  const title = input.postTitle || 'your post'
+  let card: NotificationEmailContent | null = null
+  let preheader = ''
+
+  switch (input.typeKey) {
+    case 'post.status_changed': {
+      const label = (STATUS_CONFIG[(input.to ?? 'open') as keyof typeof STATUS_CONFIG] ?? STATUS_CONFIG.open).label
+      card = statusChangeCard(title, input.to ?? 'open', input.note)
+      preheader = `"${title}" is now ${label}.`
+      break
+    }
+    case 'post.admin_replied':
+      card = adminReplyCard(title, input.actorName ?? 'The team', input.actorImage, input.snippet ?? '')
+      preheader = `An official reply on "${title}".`
+      break
+    default:
+      return null
+  }
+
+  const html = notificationShell(card.html.replaceAll('{{postUrl}}', input.postUrl), preheader)
+  const text = `${card.text}\n\nView: ${input.postUrl}\n\n—\n${FOOTER_REASON}`
+  return { subject: card.subject, html, text }
 }

--- a/server/utils/email.ts
+++ b/server/utils/email.ts
@@ -6,6 +6,7 @@ export interface SendEmailOptions {
   subject: string
   html: string
   text?: string
+  headers?: Record<string, string> // custom headers, e.g. List-Unsubscribe (RFC 8058)
 }
 
 export interface EmailProvider {
@@ -35,6 +36,9 @@ export function resolveEmailProvider(): EmailProvider {
   throw new Error('No email provider registered')
 }
 
-export async function sendEmail(options: SendEmailOptions) {
-  await resolveEmailProvider().send(options)
+export async function sendEmail(options: SendEmailOptions): Promise<void> {
+  // Defense-in-depth: a subject is a single header line, so collapse any CR/LF —
+  // a subject carrying user data (post title, org name) can't inject extra headers.
+  const subject = options.subject.replace(/[\r\n]+/g, ' ')
+  await resolveEmailProvider().send({ ...options, subject })
 }

--- a/server/utils/notification-send.ts
+++ b/server/utils/notification-send.ts
@@ -1,0 +1,60 @@
+import { sendEmail, type SendEmailOptions } from './email'
+import { buildPostLink } from './post-link-builder'
+import { renderNotificationEmail } from './email-templates'
+import { type NotificationTypeKey } from '../../shared/constants/notifications'
+import { type NotificationPayload } from '../db/schemas'
+
+// One recipient's decision + delivery, run inline in the triggering request's
+// waitUntil. Recipients are already resolved and English-only, so everything the
+// email needs is here.
+
+export interface SendNotificationInput {
+  orgId: string
+  orgSlug: string
+  recipientEmail: string
+  typeKey: NotificationTypeKey
+  postSlug: string
+  postTitle: string
+  payload: NotificationPayload
+  // Origin the triggering request arrived on; the link builder's fallback when
+  // BETTER_AUTH_URL is unset (it is optional in OSS).
+  requestOrigin?: string
+}
+
+// Returns null for a type with no email template (a config error; the caller
+// logs it rather than sending blank).
+function buildNotificationEmail(input: SendNotificationInput): SendEmailOptions | null {
+  const content = renderNotificationEmail({
+    typeKey: input.typeKey,
+    postTitle: input.postTitle,
+    postUrl: buildPostLink(input.orgSlug, `/p/${input.postSlug}`, input.requestOrigin),
+    to: input.payload.to,
+    note: input.payload.note,
+    snippet: input.payload.snippet,
+    actorName: input.payload.actorName,
+    actorImage: input.payload.actorImage,
+  })
+  if (!content) return null
+  return { to: input.recipientEmail, subject: content.subject, html: content.html, text: content.text }
+}
+
+export async function sendNotification(input: SendNotificationInput): Promise<void> {
+  const options = buildNotificationEmail(input)
+  if (!options) {
+    console.error(`[notifications] no template for type=${input.typeKey} org=${input.orgId}`)
+    return
+  }
+
+  // At-most-once: one immediate retry for transient jitter, then give up.
+  try {
+    await sendEmail(options)
+  }
+  catch {
+    try {
+      await sendEmail(options)
+    }
+    catch (err) {
+      console.error(`[notifications] send failed org=${input.orgId} type=${input.typeKey}`, err)
+    }
+  }
+}

--- a/server/utils/notifications.ts
+++ b/server/utils/notifications.ts
@@ -1,0 +1,123 @@
+import { eq, sql } from 'drizzle-orm'
+import { useDB } from './db'
+import { sendNotification } from './notification-send'
+import { resolveCommentEvents } from '../../shared/utils/notifications'
+import { organization, user } from '../db/schemas'
+import type { NotificationPayload } from '../db/schemas'
+
+// DB-touching notification emit. Pure who/whether decisions live in
+// shared/utils/notifications.ts; the per-recipient send lives in
+// notification-send.ts. This module answers only WHO.
+//
+//  · Recipients = whoever is subscribed to this post (across the whole merge
+//    family), minus org admins and the acting user. Authorship and votes have
+//    already written subscription rows, so the table IS the audience.
+//  · Resolving is one SELECT; sending is a loop the caller owns (inside
+//    waitUntil), so a failure is logged, never thrown.
+
+export type PostThreadType = 'post.status_changed' | 'post.admin_replied'
+
+export interface CommentEmitInput {
+  orgId: string
+  postId: string
+  snippet: string
+  actorId: string
+  authorIsAdmin: boolean
+  isTopLevel: boolean
+  notifyVoters: boolean // false → skip upvoters (author + manual subscribers still get it)
+  requestOrigin?: string // link-builder fallback; BETTER_AUTH_URL is optional in OSS
+}
+
+export interface RecipientRow {
+  user_id: string
+  email: string
+  post_slug: string
+  post_title: string
+}
+
+// The post's subscribers across its merge family. Excludes org admins and the
+// actor. includeVoters=false also drops upvoters (the author subscribed via
+// authorship, not a vote, so they survive).
+export async function resolvePostThreadRecipients(orgId: string, postId: string, actorId: string, includeVoters = true): Promise<RecipientRow[]> {
+  const db = useDB()
+  const excludeVoters = includeVoters
+    ? sql``
+    : sql`AND NOT EXISTS (SELECT 1 FROM vote v WHERE v.user_id = ps.user_id AND v.post_id IN (SELECT id FROM family))`
+  return await db.execute(sql`
+    WITH RECURSIVE family AS (
+      SELECT id FROM post WHERE id = ${postId}::uuid
+      UNION ALL
+      SELECT p.id FROM post p JOIN family f ON p.merged_to = f.id
+    )
+    SELECT DISTINCT ps.user_id, u.email, pp.slug AS post_slug, pp.title AS post_title
+    FROM post_subscription ps
+    JOIN "user" u ON u.id = ps.user_id
+    CROSS JOIN (SELECT slug, title FROM post WHERE id = ${postId}::uuid) pp
+    WHERE ps.post_id IN (SELECT id FROM family)
+      AND ps.user_id <> ${actorId}
+      AND u.email IS NOT NULL
+      ${excludeVoters}
+      AND NOT EXISTS (
+        SELECT 1 FROM member m
+        WHERE m.user_id = ps.user_id AND m.organization_id = ${orgId}
+          AND m.role IN ('owner', 'manager')
+      )
+  `) as unknown as RecipientRow[]
+}
+
+export async function resolveOrgSlug(orgId: string): Promise<string> {
+  const db = useDB()
+  const rows = await db.select({ slug: organization.slug }).from(organization).where(eq(organization.id, orgId)).limit(1)
+  return rows[0]?.slug ?? ''
+}
+
+// Mail an already-resolved recipient set. Called inside waitUntil.
+export async function deliverToRecipients(
+  orgId: string,
+  orgSlug: string,
+  recipients: RecipientRow[],
+  typeKey: PostThreadType,
+  payload: NotificationPayload,
+  requestOrigin?: string,
+): Promise<void> {
+  for (const r of recipients) {
+    await sendNotification({
+      orgId,
+      orgSlug,
+      recipientEmail: r.email,
+      typeKey,
+      postSlug: r.post_slug,
+      postTitle: r.post_title,
+      payload,
+      requestOrigin,
+    })
+  }
+}
+
+// Comment path — resolve and deliver in one go; the caller doesn't need a count.
+async function emitAdminReply(input: CommentEmitInput): Promise<void> {
+  const db = useDB()
+  const orgSlug = await resolveOrgSlug(input.orgId)
+  if (!orgSlug) {
+    console.error(`[notifications] no org slug, skipping org=${input.orgId}`)
+    return
+  }
+  const recipients = await resolvePostThreadRecipients(input.orgId, input.postId, input.actorId, input.notifyVoters)
+  if (recipients.length === 0) return
+
+  // Actor is the same for every recipient — resolve once for the email.
+  const [actor] = await db.select({ name: user.name, image: user.image }).from(user).where(eq(user.id, input.actorId)).limit(1)
+  await deliverToRecipients(input.orgId, orgSlug, recipients, 'post.admin_replied', {
+    snippet: input.snippet.slice(0, 280),
+    actorName: actor?.name ?? undefined,
+    actorImage: actor?.image ?? null,
+  }, input.requestOrigin)
+}
+
+// Only an admin's top-level comment notifies anyone (official reply).
+export async function emitCommentNotifications(input: CommentEmitInput): Promise<void> {
+  const events = resolveCommentEvents({ isTopLevel: input.isTopLevel, authorIsAdmin: input.authorIsAdmin })
+  for (const typeKey of events) {
+    if (typeKey === 'post.admin_replied') await emitAdminReply(input)
+  }
+}

--- a/server/utils/post-link-builder.ts
+++ b/server/utils/post-link-builder.ts
@@ -1,0 +1,26 @@
+// Where a notification email's deep-link points — a layer↔app seam. The link must
+// name the recipient's canonical host, not whichever host triggered the send, so it
+// never reads the request directly; SaaS overrides it to {orgSlug}.{ROOT_DOMAIN}.
+// The caller passes the full path (/p/{slug} or /changelog/{slug}) so one seam
+// covers every entity, plus the triggering request's origin as a fallback.
+export type PostLinkBuilder = (orgSlug: string, path: string, requestOrigin?: string) => string
+
+// BETTER_AUTH_URL is optional in OSS (README: inferred from the request Host), so
+// prefer explicit config, then the origin the request actually arrived on. With
+// neither, throw: the caller logs and drops the mail, which beats emailing a link
+// to a host the recipient can't reach — that one can't be taken back.
+const defaultBuilder: PostLinkBuilder = (_orgSlug, path, requestOrigin) => {
+  const baseUrl = process.env.BETTER_AUTH_URL || requestOrigin
+  if (!baseUrl) throw new Error('[post-link] no base URL: set BETTER_AUTH_URL or pass requestOrigin')
+  return `${baseUrl}${path}`
+}
+
+let _builder: PostLinkBuilder = defaultBuilder
+
+export function registerPostLinkBuilder(builder: PostLinkBuilder): void {
+  _builder = builder
+}
+
+export function buildPostLink(orgSlug: string, path: string, requestOrigin?: string): string {
+  return _builder(orgSlug, path, requestOrigin)
+}

--- a/shared/constants/notifications.ts
+++ b/shared/constants/notifications.ts
@@ -1,0 +1,8 @@
+// Notification system — the two notification type keys. Recipients are resolved
+// from post_subscription (server/utils/notifications.ts), not a per-type audience.
+
+export const NOTIFICATION_TYPE_KEYS = [
+  'post.status_changed',
+  'post.admin_replied',
+] as const
+export type NotificationTypeKey = (typeof NOTIFICATION_TYPE_KEYS)[number]

--- a/shared/types/post.ts
+++ b/shared/types/post.ts
@@ -68,6 +68,7 @@ export interface PostDetail {
   mergedCount: number
   mergedTo: string | null
   hasVoted: boolean
+  subscribed?: boolean
   author: PostAuthor
   createdAt: string
   updatedAt: string

--- a/shared/utils/notifications.ts
+++ b/shared/utils/notifications.ts
@@ -1,0 +1,27 @@
+// Pure notification helpers — no DB, no Nuxt runtime, so they unit-test in
+// isolation (pure functions are the highest-value tests). The
+// DB-touching emit/send logic lives in server/utils/notifications.ts.
+
+import { type NotificationTypeKey } from '../constants/notifications'
+
+export interface OrgListSession {
+  orgList?: { orgId: string; role: string }[]
+}
+
+// A comment author is an admin (→ official reply) when their session role in
+// this org is owner or manager — read straight from the session, no DB query.
+// Portal SSO sessions carry no orgList, so they are never admins.
+export function isActorAdmin(session: OrgListSession, orgId: string): boolean {
+  const role = session.orgList?.find(o => o.orgId === orgId)?.role
+  return role === 'owner' || role === 'manager'
+}
+
+// The comment decision table: which event types a new comment fires. Only an
+// admin's top-level comment notifies anyone (official reply → owner + voters).
+// A reply notifies nobody, and neither does an ordinary user's top-level
+// comment — both are deliberate, not gaps.
+export function resolveCommentEvents(input: { isTopLevel: boolean; authorIsAdmin: boolean }): NotificationTypeKey[] {
+  if (!input.isTopLevel) return []
+  if (input.authorIsAdmin) return ['post.admin_replied']
+  return []
+}


### PR DESCRIPTION
## What this PR does

  Adds membership-based email notifications. Authors and upvoters are subscribed to a
  post automatically (and anyone can subscribe/unsubscribe explicitly), then receive an
  English email on the two moments that matter:

  - the post's **status changes**, or
  - the **team posts an official reply**.

  Ships the subscribe/unsubscribe endpoints + UI, two email templates, a `post_subscription`
  table (migration `0006`), and a small `registerPostLinkBuilder` seam so the email deep-link
  points at the recipient's canonical host. Admins are never self-notified. Requires an email
  provider to be configured.

  ## Why

  Feedback authors and upvoters have no way to hear back once they've posted — they have to
  keep re-checking the portal. This closes the loop on the two events people actually care
  about (status change, official reply), gated on a subscription so it stays opt-in rather
  than noisy.

  ## How to review

  - Read order: `server/utils/notifications.ts` (who gets notified) → `notification-send.ts`
    (one recipient's email) → `email-templates.ts` (the two templates).
  - `server/utils/post-link-builder.ts` is an intentional seam: the deep-link must name the
    recipient's canonical host, not the triggering request's. OSS falls back to
    `BETTER_AUTH_URL` then the request origin; downstream deployments override via
    `registerPostLinkBuilder`.
  - Emails are English-only for this iteration — recipients don't carry a guaranteed locale
    at send time.
  - New table + migration `0006_puzzling_mantis`; run `pnpm migrate`. No new env var (reuses
    the optional `BETTER_AUTH_URL`).
  - You can skip the `pnpm-lock.yaml` churn.

  ## Checklist

  - [x] Commits are signed off (`git commit -s`)
  - [x] Tests pass locally (`pnpm build`)
  - [x] If schema changed, migration was generated (`pnpm generate:migration`) and committed
  - [x] If public API or env vars changed, `README.md` / `.env.example` / `docs/deploy/*` updated
  - [x] No secrets, internal URLs, or team member names in the diff
