### PR TITLE
Fix/bugfix

### DIFF
--- a/app/components/roadmap/RoadmapKanban.vue
+++ b/app/components/roadmap/RoadmapKanban.vue
@@ -482,7 +482,7 @@ function removeItem(postId: string) {
       <div
         v-if="col.items.length || ghostPreview?.status === col.id || pendingDrop?.toStatus === col.id"
         :ref="(el) => setScrollableRef(col.id, el)"
-        class="flex-1 overflow-y-auto pr-1"
+        class="kanban-scroll flex-1 overflow-y-auto pr-1"
       >
         <TransitionGroup
           name="kanban-card"
@@ -566,6 +566,27 @@ function removeItem(postId: string) {
   background-color: color-mix(in oklab, var(--foreground) 5%, transparent);
   border-radius: 16px;
   padding: 12px;
+}
+
+.kanban-scroll {
+  scrollbar-width: thin;
+  scrollbar-color: color-mix(in oklab, var(--foreground) 22%, transparent) transparent;
+}
+.kanban-scroll::-webkit-scrollbar {
+  width: 6px;
+}
+.kanban-scroll::-webkit-scrollbar-track {
+  background: transparent;
+}
+.kanban-scroll::-webkit-scrollbar-thumb {
+  background-color: color-mix(in oklab, var(--foreground) 22%, transparent);
+  border-radius: 4px;
+  border: 2px solid transparent;
+  background-clip: padding-box;
+}
+.kanban-scroll::-webkit-scrollbar-thumb:hover {
+  background-color: color-mix(in oklab, var(--foreground) 34%, transparent);
+  border-width: 3px;
 }
 
 /* Card enter: expand from 0 height + fade in */

--- a/app/components/ui/button/index.ts
+++ b/app/components/ui/button/index.ts
@@ -13,7 +13,7 @@ export const buttonVariants = cva(
         destructive:
           "bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
         outline:
-          "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50",
+          "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50 dark:hover:text-foreground",
         secondary:
           "bg-secondary text-secondary-foreground hover:bg-secondary/80",
         ghost:

--- a/app/plugins/md-editor-config.client.ts
+++ b/app/plugins/md-editor-config.client.ts
@@ -1,9 +1,15 @@
 import { config } from 'md-editor-v3'
+import { resolveAttachmentUrls } from '~/utils/attachment'
 
 export default defineNuxtPlugin(() => {
   config({
     codeMirrorExtensions(extensions) {
       return extensions.filter(ext => ext.type !== 'linkShortener')
+    },
+    markdownItConfig(md) {
+      md.core.ruler.before('normalize', 'resolve_attachments', (state) => {
+        state.src = resolveAttachmentUrls(state.src)
+      })
     },
   })
 })

--- a/app/utils/attachment.ts
+++ b/app/utils/attachment.ts
@@ -9,7 +9,7 @@ export function resolveAttachmentUrl(key: string | null | undefined): string | n
   return `/api/files/${key}`
 }
 
-const ATTACHMENT_MD_RE = /(!\[[^\]]*\]\()attachment:([^\s)]+)(\))/g
+const ATTACHMENT_MD_RE = /(!\[[^\]]*\]\()attachment:([^)]+)(\))/g
 const ATTACHMENT_HTML_RE = /(src=["'])attachment:([^"']+)(["'])/g
 
 /**
@@ -19,7 +19,7 @@ const ATTACHMENT_HTML_RE = /(src=["'])attachment:([^"']+)(["'])/g
  * e.g. ![alt](attachment:uploads/img.png) → ![alt](/api/files/uploads/img.png)
  */
 export function resolveAttachmentUrls(markdown: string): string {
-  return markdown.replace(ATTACHMENT_MD_RE, '$1/api/files/$2$3')
+  return markdown.replace(ATTACHMENT_MD_RE, (_m, pre, key, post) => `${pre}/api/files/${encodeURI(key)}${post}`)
 }
 
 /**


### PR DESCRIPTION
What this PR does
  
  Four small, independent UI/rendering fixes. No schema, API, or env changes — 4 files, +31/−4.

  - Attachment images whose filename contains a space never rendered (2 commits, one per render path):
    - Reader: ATTACHMENT_MD_RE used [^\s)]+, so it stopped at the first space and left the attachment: prefix in place. Widened to [^)]+ and percent-encoded the key with encodeURI — widening alone isn't enough, because markdown-it refuses to emit an <img> for a URL containing raw spaces.
    - Editor preview: md-editor-v3 renders markdown before sanitizeAttachmentHtml runs, so there is no <img> left to rewrite. Added a markdown-it core rule (before normalize) that runs resolveAttachmentUrls on the source instead.
  - Outline buttons became unreadable on hover in dark mode. The outline variant swaps the dark hover background to input/50 but kept hover text at accent-foreground, which is paired with the accent background. With a branded dark accent-foreground the label vanished against the neutral hover background. Pinned dark hover text to foreground.
  - Roadmap kanban columns fell back to the wide native scrollbar. Added a theme-aware color-mix scrollbar; a transparent border plus background-clip: padding-box narrows the visible thumb on hover without changing track width, so no content shifts.

  Why

  Each is a user-visible rendering defect reproducible on main; the attachment one came from a real upload (a screenshot whose default filename contains spaces), which silently degrades to literal markdown text in the post body.

  How to review

  Read them independently — the four commits share no code except the two attachment ones, which are the same bug on the two different render paths (app/utils/attachment.ts for the reader, app/plugins/md-editor-config.client.ts for the editor preview). Suggested order: attachment.ts first, then the plugin.

  Repro steps:

  1. Attachments — upload an image whose filename contains a space (e.g. my screenshot.png), insert it into a post. On main both the editor preview pane and the published post show literal `![...](attachment:...)` text; after this PR both render the image.
  2. Outline button — switch to dark mode, hover any variant="outline" button. Most visible on an org with a customized brand color.
  3. Kanban scrollbar — open a roadmap board with a column tall enough to overflow, then hover/scroll it.

  Not worth worrying about:

  - encodeURI rather than encodeURIComponent in resolveAttachmentUrls — deliberate: encodeURIComponent would also escape the / path separators in the storage key.
  - The markdown-it rule is idempotent, so it's safe on content that was already resolved upstream (the reader's MdPreview).
  - Stored attachment keys are untouched; this fixes existing posts at render time.

  Checklist

  - [x] Commits are signed off (git commit -s)
  - [x] Tests pass locally (pnpm build)
  - [x] If schema changed, migration was generated — n/a, no schema change
  - [x] If public API or env vars changed, docs updated — n/a, no public API or env change
  - [x] No secrets, internal URLs, or team member names in the diff