### PR TITLE
feat(submit): pre-fill the feedback form from URL params

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,7 @@ logs
 .wrangler/
 .vercel
 .env*.local
+
+# Agent scratch space (screenshots, debug dumps, ad-hoc scripts)
+tmp/
+.playwright-mcp/

--- a/app/components/post/SubmitModal.vue
+++ b/app/components/post/SubmitModal.vue
@@ -3,7 +3,11 @@ import '~/assets/css/md-editor-preview.css'
 import { preventShadcnDialogClose } from '~/lib/md-editor-helper';
 import { sanitizeAttachmentHtml } from '~/utils/attachment';
 
-const props = defineProps<{ defaultBoardId?: string }>()
+const props = defineProps<{
+  defaultBoardId?: string
+  /** Seed values from a pre-filled submit link (`/?new=1&title=&body=`). */
+  prefill?: { title?: string; body?: string }
+}>()
 const open = defineModel<boolean>('open', { default: false })
 const emit = defineEmits<{ created: [slug: string] }>()
 
@@ -11,6 +15,12 @@ const { t, locale } = useI18n()
 
 const boardStore = useBoardStore()
 const { boards } = storeToRefs(boardStore)
+
+const { data: session } = useAuthSession()
+const isLoggedIn = computed(() => !!session.value?.user)
+const loginModal = useLoginModal()
+// The user pressed submit while signed out; resume once a session appears.
+const awaitingLogin = ref(false)
 
 const selectedBoardId = ref<string | null>(null)
 const title = ref('')
@@ -81,6 +91,7 @@ function reset() {
   error.value = ''
   similarPosts.value = []
   showDetailSlug.value = null
+  awaitingLogin.value = false
 }
 
 async function handleSubmit() {
@@ -94,6 +105,16 @@ async function handleSubmit() {
   }
   if (!content.value.trim()) {
     error.value = t('post.submit.errors.contentRequired')
+    return
+  }
+
+  // Only reachable from a pre-filled link: every other entry point still gates
+  // on sign-in before opening the form. Arriving with a draft already written
+  // is what earns the deferral — the auth prompt waits until it would cost the
+  // reporter something to walk away.
+  if (!isLoggedIn.value) {
+    awaitingLogin.value = true
+    loginModal.open()
     return
   }
 
@@ -121,10 +142,21 @@ async function handleSubmit() {
   }
 }
 
+// Sign-in happens in place (OAuth runs in a popup, email posts via fetch), so
+// the draft is still in memory here — finish the submit the user already asked
+// for instead of making them press the button twice.
+watch(isLoggedIn, (v) => {
+  if (!v || !awaitingLogin.value) return
+  awaitingLogin.value = false
+  void handleSubmit()
+})
+
 // Set default board when modal opens, reset when it closes
 watch(open, (v) => {
   if (v) {
     selectedBoardId.value = props.defaultBoardId ?? boards.value[0]?.id ?? null
+    if (props.prefill?.title) title.value = props.prefill.title
+    if (props.prefill?.body) content.value = props.prefill.body
   } else {
     reset()
   }
@@ -212,7 +244,9 @@ watch(open, (v) => {
           :disabled="submitting"
           @click="handleSubmit"
         >
-          {{ submitting ? $t('post.submit.submitting') : $t('post.submit.submit') }}
+          <template v-if="submitting">{{ $t('post.submit.submitting') }}</template>
+          <template v-else-if="!isLoggedIn">{{ $t('post.submit.signInAndSubmit') }}</template>
+          <template v-else>{{ $t('post.submit.submit') }}</template>
         </button>
       </div>
 

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -23,7 +23,19 @@ const { boards, boardMap, totalPostCount } = storeToRefs(boardStore)
 // Currently selected board and sort order
 const route = useRoute()
 const router = useRouter()
-const activeBoardId = computed(() => (route.query.b as string) || null)
+
+// `?b=` accepts a board id or its name, so pre-filled links can be hand-written
+// without looking up a uuid in the dashboard. Names are matched only once the
+// board store has loaded; until then this reads as "no filter".
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+const activeBoardId = computed(() => {
+  const raw = (route.query.b as string) || null
+  if (!raw) return null
+  if (UUID_RE.test(raw)) return raw
+  const wanted = raw.trim().toLowerCase()
+  // Board names carry no uniqueness constraint — first by position wins.
+  return boards.value.find(b => b.name.toLowerCase() === wanted)?.id ?? null
+})
 const sortBy = ref<'top' | 'recent'>('recent')
 
 // Post list
@@ -150,6 +162,34 @@ const postDetailStore = usePostDetailStore()
 const showDetail = ref(false)
 const showSubmit = ref(false)
 const detailSlug = ref<string | null>(null)
+
+// Pre-filled submit links: /?new=1&title=...&body=...&b=...
+// This is the one entry point that opens the form to signed-out visitors — they
+// arrive holding a draft, so making them sign in first would throw it away.
+// Caps mirror the form's own limits; over-long values are truncated rather than
+// rejected, since a broken link should still get the reporter to a usable form.
+const submitPrefill = ref<{ title?: string; body?: string }>()
+
+onMounted(() => {
+  const q = route.query
+  // `?new` with no value parses to null — bare presence counts as enabled.
+  if (q.new === undefined || q.new === '0' || q.new === 'false') return
+
+  submitPrefill.value = {
+    title: typeof q.title === 'string' ? q.title.slice(0, 200) : undefined,
+    body: typeof q.body === 'string' ? q.body.slice(0, 10000) : undefined,
+  }
+  showSubmit.value = true
+
+  // Strip the one-shot params: otherwise a refresh replays the draft, and
+  // sharing the current URL hands your draft to someone else. `b` stays — it is
+  // the list's filter state, not part of the prefill.
+  const query = { ...q }
+  delete query.new
+  delete query.title
+  delete query.body
+  router.replace({ query })
+})
 
 // Open post detail modal with prefill from list data
 function openPostDetail(item: PostListItem) {
@@ -441,7 +481,12 @@ async function handleVote(post: PostListItem) {
   <PostDetailModal v-model:open="showDetail" :slug="detailSlug" @updated="onPostUpdated" @deleted="onPostDeleted" />
 
   <!-- Submit feedback modal -->
-  <SubmitModal v-model:open="showSubmit" :default-board-id="activeBoardId ?? undefined" @created="refreshPosts()" />
+  <SubmitModal
+    v-model:open="showSubmit"
+    :default-board-id="activeBoardId ?? undefined"
+    :prefill="submitPrefill"
+    @created="refreshPosts()"
+  />
 </template>
 
 <style scoped>

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -199,6 +199,7 @@
       "bodyPlaceholder": "Explain your thoughts in detail...",
       "submitting": "Submitting...",
       "submit": "Post Feedback",
+      "signInAndSubmit": "Sign in & Post",
       "dialogTitle": "Submit Feedback",
       "dialogDescription": "Submit new feedback",
       "errors": {

--- a/i18n/locales/zh.json
+++ b/i18n/locales/zh.json
@@ -199,6 +199,7 @@
       "bodyPlaceholder": "详细描述你的想法……",
       "submitting": "提交中……",
       "submit": "发布反馈",
+      "signInAndSubmit": "登录并发布",
       "dialogTitle": "提交反馈",
       "dialogDescription": "提交新反馈",
       "errors": {


### PR DESCRIPTION
## What this PR does

  Adds pre-filled submit links to the portal home page — `/?new=1&title=…&body=…&b=…` opens the feedback form with the fields already filled in.

  - `new=1` is the switch; without it none of the other params are parsed (so the existing `?b=` board filter keeps its current meaning).
  - `title` / `body` mirror GitHub's `issues/new?title=&body=` — the strongest existing mental model for this, and most self-hosters are developers. `body` is plain Markdown; over-long values are truncated (200 / 10000, matching the form's own limits) rather than rejected, so a
  sloppy link still lands the reporter on a usable form.
  - `b` now accepts a **board name** as well as a uuid, so links can be hand-written without copying an id out of the dashboard. Names are matched case-insensitively; board names have no uniqueness constraint, so the first by position wins.
  - The one-shot params (`new` / `title` / `body`) are stripped via `router.replace` once consumed — otherwise a refresh replays the draft and sharing the current URL hands your draft to someone else. `b` stays, since it is the list's filter state.
  - **Never auto-submits.** The issue asks for pre-fill only, and it is also the safety line: otherwise one crafted link posts as whoever clicks it.
  - This is the one entry point that opens the form to signed-out visitors. They arrive holding a draft, so the sign-in prompt defers until they press submit; after signing in, the submit they already asked for completes on its own. Every other entry point ("New Request" button,
  empty-search CTA) still gates on sign-in before opening the form — unchanged.

  No schema, migration, API field, or env var changes.

  ## Why

  Requested in #9 — carry form content in URL params so a host product can hand users a partly-written report instead of a blank form.

  The real obstacle was never the parsing. It is the entry point: click the link → hit the sign-in wall → the draft you were handed is gone. So this PR pairs the params with deferred sign-in on that one path, which is what makes the feature actually worth clicking.

  Scope notes on what was deliberately left out:

  - **Anonymous feedback** is out of scope — it drags in spam protection, identity merging, and notification ownership, and shouldn't be settled as a side effect of this. This PR only makes sure the login step doesn't cost you your text.
  - **Metadata / source context** (app version, OS, page URL, à la Featurebase's `metaData`) is more valuable than title pre-fill, but needs storage, a place in the detail view, and a privacy boundary — and it overlaps heavily with the widget SDK's context capture. Better designed
  there than as a second implementation here.
  - **No link-generator UI** in the dashboard yet; the param contract plus a docs page is enough until someone actually uses it.

  Closes #9

  ## How to review

  Start at `app/pages/index.vue` — the `onMounted` block is the whole entry path (parse → seed → strip). `activeBoardId` just above it is where `?b=` gained name resolution. Then `SubmitModal.vue`, where the only behavioural change is `handleSubmit` bailing to the login modal when
  signed out, and the `watch(isLoggedIn)` that resumes it.

  Try it locally against any board:

  http://localhost:3000/?new=1&b=Bug%20Report&title=Upload%20fails%20on%20Safari&body=Steps%3A%0A1.%20...

  Verified in a real browser, signed out: form opens with the board selected by name and the body's newlines intact, the button reads "Sign in & Post", the address bar collapses to `?b=Bug+Report`, and signing in completes the submit exactly once (`POST /api/posts` 201) onto the
  right board. In the same signed-out session, "New Request" still prompts for sign-in first.