### PR TITLE
Feat/email notifications

### DIFF
--- a/app/components/comment/CommentItem.vue
+++ b/app/components/comment/CommentItem.vue
@@ -115,6 +115,13 @@ function initials(name: string | null) {
           <span class="font-heading font-bold" :class="depth ? 'text-xs' : 'text-sm'">
             {{ comment.author?.name ?? $t('common.anonymous') }}
           </span>
+          <span
+            v-if="comment.author?.isAdmin"
+            class="inline-flex items-center shrink-0 rounded-full bg-primary text-primary-foreground font-medium px-2 py-0.5"
+            :class="depth ? 'text-[10px]' : 'text-xs'"
+          >
+            {{ $t('post.comment.adminBadge') }}
+          </span>
           <span v-if="replyToName" class="inline-flex items-center gap-0.5 text-muted-foreground" :class="depth ? 'text-[10px]' : 'text-xs'">
             <Icon name="lucide:corner-down-right" :size="depth ? '10' : '12'" />
             <span class="font-medium">@{{ replyToName }}</span>

--- a/app/stores/postDetail.ts
+++ b/app/stores/postDetail.ts
@@ -261,7 +261,7 @@ export const usePostDetailStore = defineStore('postDetail', () => {
   }
 
   async function updateComment(slug: string, commentId: string, content: string) {
-    const res = await useApiFetch<CommentItem>(
+    const res = await useApiFetch<Partial<CommentItem>>(
       `/api/comments/${commentId}`,
       { method: 'PATCH', body: { content } },
     )
@@ -376,19 +376,19 @@ export const usePostDetailStore = defineStore('postDetail', () => {
     return null
   }
 
-  function updateCommentInList(slug: string, commentId: string, updated: CommentItem) {
+  function updateCommentInList(slug: string, commentId: string, updated: Partial<CommentItem>) {
     const postId = posts.value[slug]?.id
     if (!postId) return
     const list = commentsMap.value[postId] ?? []
     for (let i = 0; i < list.length; i++) {
       if (list[i].id === commentId) {
-        list[i] = { ...updated, children: list[i].children }
+        list[i] = { ...list[i], ...updated }
         return
       }
       if (list[i].children) {
         for (let j = 0; j < list[i].children!.length; j++) {
           if (list[i].children![j].id === commentId) {
-            list[i].children![j] = updated
+            list[i].children![j] = { ...list[i].children![j], ...updated }
             return
           }
         }

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -283,7 +283,8 @@
       "deleteDescription": "This action cannot be undone. This will permanently delete the comment and all its replies.",
       "notifyUpvoters": "Notify upvoters",
       "notifyUpvotersHint": "Also email upvoters. The author and subscribers always get it.",
-      "emailUpvoters": "Email upvoters"
+      "emailUpvoters": "Email upvoters",
+      "adminBadge": "Admin"
     },
     "statusNotify": {
       "title": "Notify upvoters by email?",

--- a/i18n/locales/zh.json
+++ b/i18n/locales/zh.json
@@ -283,7 +283,8 @@
       "deleteDescription": "此操作无法撤销,将永久删除该评论及其所有回复。",
       "notifyUpvoters": "通知点赞者",
       "notifyUpvotersHint": "额外通知点赞过的人。作者和已订阅的人始终会收到。",
-      "emailUpvoters": "邮件通知点赞者"
+      "emailUpvoters": "邮件通知点赞者",
+      "adminBadge": "管理员"
     },
     "statusNotify": {
       "title": "要给点赞者发邮件通知吗？",

--- a/server/api/admin/posts/[id]/notify-status.post.ts
+++ b/server/api/admin/posts/[id]/notify-status.post.ts
@@ -2,7 +2,7 @@ import { z } from 'zod'
 import { and, eq } from 'drizzle-orm'
 import { getRequestURL } from 'h3'
 import { post } from '#layers/feedlog/server/db/schemas'
-import { resolvePostThreadRecipients, resolveOrgSlug, deliverToRecipients } from '#layers/feedlog/server/utils/notifications'
+import { resolvePostThreadRecipients, resolveOrgBranding, deliverToRecipients } from '#layers/feedlog/server/utils/notifications'
 import { POST_STATUSES } from '#layers/feedlog/shared/types/post'
 
 // POST /api/admin/posts/:id/notify-status — mail the post's subscribers that it
@@ -34,12 +34,12 @@ export default defineEventHandler(async (event) => {
   }
 
   // Resolve recipients synchronously so we can return the count; send async.
-  const orgSlug = await resolveOrgSlug(orgId)
+  const { slug: orgSlug, brandColor } = await resolveOrgBranding(orgId)
   const recipients = orgSlug ? await resolvePostThreadRecipients(orgId, id, session.user.id) : []
 
   if (recipients.length > 0) {
     event.waitUntil(
-      deliverToRecipients(orgId, orgSlug, recipients, 'post.status_changed',
+      deliverToRecipients(orgId, orgSlug, brandColor, recipients, 'post.status_changed',
         { to: body.status, note: body.note || undefined }, getRequestURL(event).origin)
         .catch((err: unknown) => console.error('[notifications] status notify failed', err)),
     )

--- a/server/api/posts/[postId]/comments/index.get.ts
+++ b/server/api/posts/[postId]/comments/index.get.ts
@@ -1,5 +1,5 @@
 import { eq, and, desc, asc, sql, isNull, isNotNull, inArray } from 'drizzle-orm'
-import { comment, commentLike, user, post } from '#layers/feedlog/server/db/schemas'
+import { comment, commentLike, user, post, member } from '#layers/feedlog/server/db/schemas'
 
 // GET /api/posts/:postId/comments — Unified comment query (top-level, children, pagination)
 export default defineEventHandler(async (event) => {
@@ -23,6 +23,8 @@ export default defineEventHandler(async (event) => {
   if (!postRow) {
     throw createError({ statusCode: 404, message: 'Post not found' })
   }
+
+  const adminIds = await resolveAdminAuthorIds(orgId)
 
   // Loading child comments for a specific parent
   if (parentId) {
@@ -58,7 +60,7 @@ export default defineEventHandler(async (event) => {
 
     const hasMore = rows.length > limit
     const items = hasMore ? rows.slice(0, limit) : rows
-    const data = await attachLikeStatus(db, items, session?.user.id)
+    const data = await attachLikeStatus(db, items, session?.user.id, adminIds)
 
     const lastItem = items[items.length - 1]
     return {
@@ -156,15 +158,13 @@ export default defineEventHandler(async (event) => {
     }
 
     // Attach like status to children
-    if (session?.user.id) {
-      for (const [, children] of childrenMap) {
-        const enriched = await attachLikeStatus(db, children, session.user.id)
-        children.splice(0, children.length, ...enriched)
-      }
+    for (const [, children] of childrenMap) {
+      const enriched = await attachLikeStatus(db, children, session?.user.id, adminIds)
+      children.splice(0, children.length, ...enriched)
     }
   }
 
-  const topData = await attachLikeStatus(db, topItems, session?.user.id)
+  const topData = await attachLikeStatus(db, topItems, session?.user.id, adminIds)
 
   // Enrich mergedPost entries: fetch post info + sub-post comments
   const mergedPostItems = topItems.filter(t => t.type === 'mergedPost' && t.metadata)
@@ -279,7 +279,7 @@ export default defineEventHandler(async (event) => {
       const allSubComments = groupedSubComments.get(mpId) ?? []
       const hasMoreSub = allSubComments.length > childrenLimit
       const subItems = hasMoreSub ? allSubComments.slice(0, childrenLimit) : allSubComments
-      const subData = await attachLikeStatus(db, subItems, session?.user.id)
+      const subData = await attachLikeStatus(db, subItems, session?.user.id, adminIds)
 
       // Enrich second-level mergedPost sub-comments with post info
       const enrichedSubData = subData.map(c => {
@@ -349,8 +349,16 @@ export default defineEventHandler(async (event) => {
   }
 })
 
+async function resolveAdminAuthorIds(orgId: string): Promise<Set<string>> {
+  const rows = await useDB()
+    .select({ userId: member.userId })
+    .from(member)
+    .where(and(eq(member.organizationId, orgId), inArray(member.role, ['owner', 'manager'])))
+  return new Set(rows.map(r => r.userId))
+}
+
 // Format comment row to API response
-function formatComment(r: any) {
+function formatComment(r: any, adminIds: Set<string>) {
   return {
     id: r.id,
     parentId: r.parentId,
@@ -358,7 +366,7 @@ function formatComment(r: any) {
     replyCount: r.replyCount ?? undefined,
     likeCount: r.likeCount,
     hasLiked: r.hasLiked ?? false,
-    author: { id: r.authorId, name: r.authorName, image: r.authorImage },
+    author: { id: r.authorId, name: r.authorName, image: r.authorImage, isAdmin: adminIds.has(r.authorId) },
     content: r.content,
     type: r.type ?? 'comment',
     editedAt: r.editedAt,
@@ -367,9 +375,9 @@ function formatComment(r: any) {
 }
 
 // Batch attach hasLiked status
-async function attachLikeStatus(db: any, items: any[], userId?: string) {
+async function attachLikeStatus(db: any, items: any[], userId: string | undefined, adminIds: Set<string>) {
   if (!userId || items.length === 0) {
-    return items.map(r => formatComment(r))
+    return items.map(r => formatComment(r, adminIds))
   }
 
   const commentIds = items.map(r => r.id)
@@ -383,7 +391,7 @@ async function attachLikeStatus(db: any, items: any[], userId?: string) {
   const likedSet = new Set(likes.map((l: any) => l.commentId))
 
   return items.map(r => ({
-    ...formatComment(r),
+    ...formatComment(r, adminIds),
     hasLiked: likedSet.has(r.id),
   }))
 }

--- a/server/api/posts/[postId]/comments/index.post.ts
+++ b/server/api/posts/[postId]/comments/index.post.ts
@@ -103,7 +103,6 @@ export default defineEventHandler(async (event) => {
     )
   }
 
-  // Fetch author info
   const [author] = await db
     .select({ id: user.id, name: user.name, image: user.image })
     .from(user)
@@ -117,7 +116,7 @@ export default defineEventHandler(async (event) => {
     replyCount: created!.replyCount,
     likeCount: created!.likeCount,
     hasLiked: false,
-    author: author ?? { id: session.user.id, name: null, image: null },
+    author: { ...(author ?? { id: session.user.id, name: null, image: null }), isAdmin: isActorAdmin(session, orgId) },
     content: created!.content,
     editedAt: created!.editedAt,
     createdAt: created!.createdAt,

--- a/server/api/posts/[postId]/comments/index.post.ts
+++ b/server/api/posts/[postId]/comments/index.post.ts
@@ -22,7 +22,7 @@ export default defineEventHandler(async (event) => {
   const db = useDB()
 
   // Verify post exists, belongs to org, and is not merged.
-  const [p] = await db.select({ id: post.id, mergedTo: post.mergedTo }).from(post)
+  const [p] = await db.select({ id: post.id, mergedTo: post.mergedTo, slug: post.slug, title: post.title }).from(post)
     .where(and(eq(post.id, postId), eq(post.orgId, orgId))).limit(1)
   if (!p) {
     throw createError({ statusCode: 404, message: 'Post not found' })
@@ -73,9 +73,9 @@ export default defineEventHandler(async (event) => {
   }
   await db.update(post).set({ commentCount: sql`${post.commentCount} + 1` }).where(eq(post.id, postId))
 
-  // Best-effort, after the write. Only an admin's top-level comment notifies
-  // (resolveCommentEvents no-ops for replies / non-admins). Author + manual
-  // subscribers always get it; upvoters only when notifyVoters isn't false.
+  // Best-effort, after the write. Subscribers only hear from an admin's top-level
+  // comment (resolveCommentEvents no-ops for replies / non-admins). Author +
+  // manual subscribers always get it; upvoters only when notifyVoters isn't false.
   event.waitUntil(
     emitCommentNotifications({
       orgId,
@@ -88,6 +88,20 @@ export default defineEventHandler(async (event) => {
       requestOrigin: getRequestURL(event).origin,
     }).catch((err: unknown) => console.error('[notifications] comment emit failed', err)),
   )
+
+  if (!isActorAdmin(session, orgId)) {
+    event.waitUntil(
+      emitAdminNotification({
+        orgId,
+        typeKey: 'post.user_commented',
+        postSlug: p.slug,
+        postTitle: p.title,
+        snippet: body.content,
+        actorId: session.user.id,
+        requestOrigin: getRequestURL(event).origin,
+      }).catch((err: unknown) => console.error('[notifications] comment admin emit failed', err)),
+    )
+  }
 
   // Fetch author info
   const [author] = await db

--- a/server/api/posts/index.post.ts
+++ b/server/api/posts/index.post.ts
@@ -1,5 +1,6 @@
 import { post, postSearch, user, postSubscription } from '#layers/feedlog/server/db/schemas'
 import { eq } from 'drizzle-orm'
+import { getRequestURL } from 'h3'
 import { createPostSchema } from '#layers/feedlog/shared/schemas/post'
 import { isActorAdmin } from '#layers/feedlog/shared/utils/notifications'
 
@@ -47,6 +48,20 @@ export default defineEventHandler(async (event) => {
   event.waitUntil(
     generatePostEmbedding(created.id, orgId, body.title, body.content, contentHash),
   )
+
+  if (!isActorAdmin(session, orgId)) {
+    event.waitUntil(
+      emitAdminNotification({
+        orgId,
+        typeKey: 'post.created',
+        postSlug: created.slug,
+        postTitle: created.title,
+        snippet: body.content,
+        actorId: session.user.id,
+        requestOrigin: getRequestURL(event).origin,
+      }).catch((err: unknown) => console.error('[notifications] post created emit failed', err)),
+    )
+  }
 
   const [author] = await db
     .select({ id: user.id, name: user.name, image: user.image })

--- a/server/api/widget/messages.post.ts
+++ b/server/api/widget/messages.post.ts
@@ -1,5 +1,6 @@
 import OpenAI from 'openai'
 import { asc, eq } from 'drizzle-orm'
+import { getRequestURL } from 'h3'
 import { board, organizationWidget } from '#layers/feedlog/server/db/schemas'
 import { buildWidgetSystemPrompt, parseWidgetAiResponse } from '#layers/feedlog/server/utils/widget-ai'
 import { isActorAdmin } from '#layers/feedlog/shared/utils/notifications'
@@ -143,6 +144,20 @@ export default defineEventHandler(async (event): Promise<WidgetMessageResponse> 
   event.waitUntil(
     generatePostEmbedding(created.id, orgId, created.title, content, created.contentHash),
   )
+
+  if (!isActorAdmin(session, orgId)) {
+    event.waitUntil(
+      emitAdminNotification({
+        orgId,
+        typeKey: 'post.created',
+        postSlug: created.slug,
+        postTitle: created.title,
+        snippet: content,
+        actorId: session.user.id,
+        requestOrigin: getRequestURL(event).origin,
+      }).catch((err: unknown) => console.error('[notifications] widget post created emit failed', err)),
+    )
+  }
 
   return {
     type: 'feedback',

--- a/server/utils/email-templates.ts
+++ b/server/utils/email-templates.ts
@@ -1,6 +1,7 @@
 // Email HTML templates — auto-imported by Nitro.
 // Brand primary color matches public/logo.svg.
 import { STATUS_CONFIG } from '../../shared/types/post'
+import { normalizeBrandHex, pickHexForeground } from '../../shared/utils/branding'
 
 const BRAND_COLOR = '#C45A46'
 const FONT_STACK = `-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif`
@@ -127,30 +128,31 @@ export interface NotificationEmailContent {
 }
 
 const FOOTER_REASON = 'You\'re receiving this because of your activity on this FeedLog board.'
+const ADMIN_FOOTER_REASON = 'You\'re receiving this because you manage this FeedLog board.'
 
 // Gray page → centered FeedLog wordmark → white rounded card → centered footer.
 // No links in the footer; the physical postal address (CAN-SPAM) is a pre-launch
 // item, not fabricated here.
-function notificationShell(cardInner: string, preheader: string): string {
+function notificationShell(cardInner: string, preheader: string, footerReason: string): string {
   return `
 <div style="background: #f6f7fb; padding: 40px 16px; font-family: ${FONT_STACK};">
   <div style="display: none; max-height: 0; overflow: hidden; mso-hide: all;">${escapeHtml(preheader)}</div>
   <div style="max-width: 560px; margin: 0 auto;">
     <div style="text-align: center; padding-bottom: 28px;">
-      <span style="font-size: 22px; font-weight: 800; color: ${BRAND_COLOR}; letter-spacing: -0.02em;">FeedLog</span>
+      <span style="font-size: 22px; font-weight: 800; color: {{brand}}; letter-spacing: -0.02em;">FeedLog</span>
     </div>
     <div style="background: #fff; border: 1px solid #eceef3; border-radius: 16px; padding: 40px 36px;">
 ${cardInner}
     </div>
     <div style="text-align: center; padding: 24px 8px 0; color: #9ca3af; font-size: 12px; line-height: 1.6;">
-      <p style="margin: 0;">${FOOTER_REASON}</p>
+      <p style="margin: 0;">${footerReason}</p>
     </div>
   </div>
 </div>`
 }
 
 function pillButton(url: string, label: string): string {
-  return `<div style="text-align: center; margin-top: 32px;"><a href="${url}" style="display: inline-block; padding: 14px 40px; background: ${BRAND_COLOR}; color: #fff; text-decoration: none; border-radius: 999px; font-weight: 700; font-size: 16px;">${label}</a></div>`
+  return `<div style="text-align: center; margin-top: 32px;"><a href="${url}" style="display: inline-block; padding: 14px 40px; background: {{brand}}; color: {{brandFg}}; text-decoration: none; border-radius: 999px; font-weight: 700; font-size: 16px;">${label}</a></div>`
 }
 
 function statusChangeCard(title: string, to: string, note?: string): NotificationEmailContent {
@@ -171,14 +173,14 @@ function statusChangeCard(title: string, to: string, note?: string): Notificatio
   }
 }
 
-function adminReplyCard(title: string, actorName: string, actorImage: string | null | undefined, snippet: string): NotificationEmailContent {
+function personCard(title: string, actorName: string, actorImage: string | null | undefined, snippet: string, buttonLabel: string): string {
   const initial = (actorName || '?').charAt(0).toUpperCase()
   // Only trust an http(s) URL as a src; anything else falls back to the initial avatar.
   const safeImage = actorImage && /^https?:\/\//i.test(actorImage) ? actorImage : null
   const avatar = safeImage
     ? `<img src="${escapeHtml(safeImage)}" width="40" height="40" style="border-radius: 999px; display: block;" alt="">`
-    : `<div style="width: 40px; height: 40px; border-radius: 999px; background: ${BRAND_COLOR}; color: #fff; font-size: 16px; font-weight: 700; text-align: center; line-height: 40px;">${escapeHtml(initial)}</div>`
-  const inner = `
+    : `<div style="width: 40px; height: 40px; border-radius: 999px; background: {{brand}}; color: {{brandFg}}; font-size: 16px; font-weight: 700; text-align: center; line-height: 40px;">${escapeHtml(initial)}</div>`
+  return `
       <p style="margin: 0 0 20px; font-size: 17px; font-weight: 700; color: #111827; line-height: 1.4;">${escapeHtml(title)}</p>
       <table cellpadding="0" cellspacing="0" style="width: 100%;"><tr>
         <td width="48" valign="top">${avatar}</td>
@@ -187,11 +189,30 @@ function adminReplyCard(title: string, actorName: string, actorImage: string | n
           <div style="font-size: 15px; color: #6b7280; line-height: 1.7;">${escapeHtml(snippet)}</div>
         </td>
       </tr></table>
-      ${pillButton('{{postUrl}}', 'View comment')}`
+      ${pillButton('{{postUrl}}', buttonLabel)}`
+}
+
+function adminReplyCard(title: string, actorName: string, actorImage: string | null | undefined, snippet: string): NotificationEmailContent {
   return {
     subject: `New comment for "${title}"`,
-    html: inner,
+    html: personCard(title, actorName, actorImage, snippet, 'View comment'),
     text: `${actorName} commented on "${title}":\n\n${snippet}`,
+  }
+}
+
+function newFeedbackCard(title: string, actorName: string, actorImage: string | null | undefined, snippet: string): NotificationEmailContent {
+  return {
+    subject: `New feedback: "${title}"`,
+    html: personCard(title, actorName, actorImage, snippet, 'View feedback'),
+    text: `${actorName} submitted new feedback, "${title}":\n\n${snippet}`,
+  }
+}
+
+function userCommentCard(title: string, actorName: string, actorImage: string | null | undefined, snippet: string): NotificationEmailContent {
+  return {
+    subject: `New reply on "${title}"`,
+    html: personCard(title, actorName, actorImage, snippet, 'View comment'),
+    text: `${actorName} replied on "${title}":\n\n${snippet}`,
   }
 }
 
@@ -206,10 +227,12 @@ export function renderNotificationEmail(input: {
   snippet?: string
   actorName?: string
   actorImage?: string | null
+  brandColor?: string
 }): NotificationEmailContent | null {
   const title = input.postTitle || 'your post'
   let card: NotificationEmailContent | null = null
   let preheader = ''
+  let footerReason = FOOTER_REASON
 
   switch (input.typeKey) {
     case 'post.status_changed': {
@@ -222,11 +245,24 @@ export function renderNotificationEmail(input: {
       card = adminReplyCard(title, input.actorName ?? 'The team', input.actorImage, input.snippet ?? '')
       preheader = `An official reply on "${title}".`
       break
+    case 'post.created':
+      card = newFeedbackCard(title, input.actorName ?? 'Someone', input.actorImage, input.snippet ?? '')
+      preheader = `New feedback on your board: "${title}".`
+      footerReason = ADMIN_FOOTER_REASON
+      break
+    case 'post.user_commented':
+      card = userCommentCard(title, input.actorName ?? 'Someone', input.actorImage, input.snippet ?? '')
+      preheader = `A new reply on "${title}".`
+      footerReason = ADMIN_FOOTER_REASON
+      break
     default:
       return null
   }
 
-  const html = notificationShell(card.html.replaceAll('{{postUrl}}', input.postUrl), preheader)
-  const text = `${card.text}\n\nView: ${input.postUrl}\n\n—\n${FOOTER_REASON}`
+  const brand = normalizeBrandHex(input.brandColor)
+  const html = notificationShell(card.html.replaceAll('{{postUrl}}', input.postUrl), preheader, footerReason)
+    .replaceAll('{{brand}}', brand)
+    .replaceAll('{{brandFg}}', pickHexForeground(brand))
+  const text = `${card.text}\n\nView: ${input.postUrl}\n\n—\n${footerReason}`
   return { subject: card.subject, html, text }
 }

--- a/server/utils/notification-send.ts
+++ b/server/utils/notification-send.ts
@@ -11,6 +11,7 @@ import { type NotificationPayload } from '../db/schemas'
 export interface SendNotificationInput {
   orgId: string
   orgSlug: string
+  brandColor: string
   recipientEmail: string
   typeKey: NotificationTypeKey
   postSlug: string
@@ -33,6 +34,7 @@ function buildNotificationEmail(input: SendNotificationInput): SendEmailOptions 
     snippet: input.payload.snippet,
     actorName: input.payload.actorName,
     actorImage: input.payload.actorImage,
+    brandColor: input.brandColor,
   })
   if (!content) return null
   return { to: input.recipientEmail, subject: content.subject, html: content.html, text: content.text }

--- a/server/utils/notifications.ts
+++ b/server/utils/notifications.ts
@@ -1,21 +1,23 @@
-import { eq, sql } from 'drizzle-orm'
+import { and, eq, inArray, ne, sql } from 'drizzle-orm'
 import { useDB } from './db'
 import { sendNotification } from './notification-send'
 import { resolveCommentEvents } from '../../shared/utils/notifications'
-import { organization, user } from '../db/schemas'
+import { resolveBranding } from '../../shared/utils/branding'
+import { member, organization, user } from '../db/schemas'
 import type { NotificationPayload } from '../db/schemas'
 
 // DB-touching notification emit. Pure who/whether decisions live in
 // shared/utils/notifications.ts; the per-recipient send lives in
 // notification-send.ts. This module answers only WHO.
 //
-//  · Recipients = whoever is subscribed to this post (across the whole merge
-//    family), minus org admins and the acting user. Authorship and votes have
-//    already written subscription rows, so the table IS the audience.
+//  · Subscriber audience = whoever is subscribed to this post (across the whole
+//    merge family), minus org admins and the acting user. Authorship and votes
+//    have already written subscription rows, so the table IS the audience.
 //  · Resolving is one SELECT; sending is a loop the caller owns (inside
 //    waitUntil), so a failure is logged, never thrown.
 
 export type PostThreadType = 'post.status_changed' | 'post.admin_replied'
+export type OrgAdminType = 'post.created' | 'post.user_commented'
 
 export interface CommentEmitInput {
   orgId: string
@@ -65,16 +67,17 @@ export async function resolvePostThreadRecipients(orgId: string, postId: string,
   `) as unknown as RecipientRow[]
 }
 
-export async function resolveOrgSlug(orgId: string): Promise<string> {
+export async function resolveOrgBranding(orgId: string): Promise<{ slug: string; brandColor: string }> {
   const db = useDB()
-  const rows = await db.select({ slug: organization.slug }).from(organization).where(eq(organization.id, orgId)).limit(1)
-  return rows[0]?.slug ?? ''
+  const rows = await db.select({ slug: organization.slug, metadata: organization.metadata }).from(organization).where(eq(organization.id, orgId)).limit(1)
+  return { slug: rows[0]?.slug ?? '', brandColor: resolveBranding(rows[0]?.metadata).primaryColor }
 }
 
 // Mail an already-resolved recipient set. Called inside waitUntil.
 export async function deliverToRecipients(
   orgId: string,
   orgSlug: string,
+  brandColor: string,
   recipients: RecipientRow[],
   typeKey: PostThreadType,
   payload: NotificationPayload,
@@ -84,6 +87,7 @@ export async function deliverToRecipients(
     await sendNotification({
       orgId,
       orgSlug,
+      brandColor,
       recipientEmail: r.email,
       typeKey,
       postSlug: r.post_slug,
@@ -97,7 +101,7 @@ export async function deliverToRecipients(
 // Comment path — resolve and deliver in one go; the caller doesn't need a count.
 async function emitAdminReply(input: CommentEmitInput): Promise<void> {
   const db = useDB()
-  const orgSlug = await resolveOrgSlug(input.orgId)
+  const { slug: orgSlug, brandColor } = await resolveOrgBranding(input.orgId)
   if (!orgSlug) {
     console.error(`[notifications] no org slug, skipping org=${input.orgId}`)
     return
@@ -107,7 +111,7 @@ async function emitAdminReply(input: CommentEmitInput): Promise<void> {
 
   // Actor is the same for every recipient — resolve once for the email.
   const [actor] = await db.select({ name: user.name, image: user.image }).from(user).where(eq(user.id, input.actorId)).limit(1)
-  await deliverToRecipients(input.orgId, orgSlug, recipients, 'post.admin_replied', {
+  await deliverToRecipients(input.orgId, orgSlug, brandColor, recipients, 'post.admin_replied', {
     snippet: input.snippet.slice(0, 280),
     actorName: actor?.name ?? undefined,
     actorImage: actor?.image ?? null,
@@ -119,5 +123,59 @@ export async function emitCommentNotifications(input: CommentEmitInput): Promise
   const events = resolveCommentEvents({ isTopLevel: input.isTopLevel, authorIsAdmin: input.authorIsAdmin })
   for (const typeKey of events) {
     if (typeKey === 'post.admin_replied') await emitAdminReply(input)
+  }
+}
+
+export interface AdminEmitInput {
+  orgId: string
+  typeKey: OrgAdminType
+  postSlug: string
+  postTitle: string
+  snippet: string
+  actorId: string
+  requestOrigin?: string
+}
+
+export async function resolveOrgAdminRecipients(orgId: string, actorId: string) {
+  const db = useDB()
+  return await db
+    .select({ userId: member.userId, email: user.email })
+    .from(member)
+    .innerJoin(user, eq(user.id, member.userId))
+    .where(and(
+      eq(member.organizationId, orgId),
+      inArray(member.role, ['owner', 'manager']),
+      ne(member.userId, actorId),
+    ))
+}
+
+export async function emitAdminNotification(input: AdminEmitInput): Promise<void> {
+  const db = useDB()
+  const { slug: orgSlug, brandColor } = await resolveOrgBranding(input.orgId)
+  if (!orgSlug) {
+    console.error(`[notifications] no org slug, skipping org=${input.orgId}`)
+    return
+  }
+  const recipients = await resolveOrgAdminRecipients(input.orgId, input.actorId)
+  if (recipients.length === 0) return
+
+  const [actor] = await db.select({ name: user.name, image: user.image }).from(user).where(eq(user.id, input.actorId)).limit(1)
+  const payload: NotificationPayload = {
+    snippet: input.snippet.slice(0, 280),
+    actorName: actor?.name ?? undefined,
+    actorImage: actor?.image ?? null,
+  }
+  for (const r of recipients) {
+    await sendNotification({
+      orgId: input.orgId,
+      orgSlug,
+      brandColor,
+      recipientEmail: r.email,
+      typeKey: input.typeKey,
+      postSlug: input.postSlug,
+      postTitle: input.postTitle,
+      payload,
+      requestOrigin: input.requestOrigin,
+    })
   }
 }

--- a/server/utils/post-create.ts
+++ b/server/utils/post-create.ts
@@ -2,8 +2,8 @@ import { eq } from 'drizzle-orm'
 import { useDB } from './db'
 import { post, postSearch, postSubscription, user } from '../db/schemas'
 
-// Shared post creation: slug, excerpt, search row, author subscription and the
-// async embedding. Extracted so the widget's AI extraction path produces posts
+// Shared post creation: slug, excerpt, search row, author subscription.
+// Extracted so the widget's AI extraction path produces posts
 // indistinguishable from ones submitted through POST /api/posts — two code
 // paths writing posts differently is how search or notifications quietly start
 // missing half the rows.

--- a/shared/constants/notifications.ts
+++ b/shared/constants/notifications.ts
@@ -1,8 +1,11 @@
-// Notification system — the two notification type keys. Recipients are resolved
-// from post_subscription (server/utils/notifications.ts), not a per-type audience.
+// Notification system — the notification type keys. Recipients are resolved in
+// server/utils/notifications.ts: the first two from post_subscription, the last
+// two from the org's owners/managers.
 
 export const NOTIFICATION_TYPE_KEYS = [
   'post.status_changed',
   'post.admin_replied',
+  'post.created',
+  'post.user_commented',
 ] as const
 export type NotificationTypeKey = (typeof NOTIFICATION_TYPE_KEYS)[number]

--- a/shared/types/comment.ts
+++ b/shared/types/comment.ts
@@ -2,6 +2,7 @@ export interface CommentAuthor {
   id: string
   name: string | null
   image: string | null
+  isAdmin?: boolean
 }
 
 export interface CommentItem {

--- a/shared/utils/branding.ts
+++ b/shared/utils/branding.ts
@@ -71,7 +71,8 @@ function oklchToLinear({ l: L, c: C, h: H }: Oklch): [number, number, number] {
 const luminance = ([r, g, b]: [number, number, number]) => 0.2126 * r + 0.7152 * g + 0.0722 * b
 const contrast = (y1: number, y2: number) => (Math.max(y1, y2) + 0.05) / (Math.min(y1, y2) + 0.05)
 const WHITE_FG = { css: 'oklch(1 0 0)', y: 1 }
-const DARK_FG = { css: 'oklch(0.275 0.009 28.9)', y: luminance(oklchToLinear({ l: 0.275, c: 0.009, h: 28.9 })) }
+const DARK_FG_OKLCH: Oklch = { l: 0.275, c: 0.009, h: 28.9 }
+const DARK_FG = { css: 'oklch(0.275 0.009 28.9)', y: luminance(oklchToLinear(DARK_FG_OKLCH)) }
 
 function pickForeground(accent: Oklch): string {
   const y = luminance(oklchToLinear(accent))
@@ -83,6 +84,19 @@ const oklchStr = ({ l, c, h }: Oklch) => `oklch(${round(l)} ${round(c)} ${round(
 
 export function isValidBrandHex(hex: string): boolean {
   return /^#[0-9a-fA-F]{6}$/.test(hex.trim())
+}
+
+const srgb = (v: number) => (v <= 0.0031308 ? v * 12.92 : 1.055 * v ** (1 / 2.4) - 0.055)
+
+function linearToHex(rgb: [number, number, number]): string {
+  return `#${rgb.map(v => Math.round(Math.max(0, Math.min(1, srgb(v))) * 255).toString(16).padStart(2, '0')).join('').toUpperCase()}`
+}
+
+export function pickHexForeground(seedHex: string): string {
+  const y = luminance(hexToLinear(normalizeBrandHex(seedHex)))
+  return contrast(y, WHITE_FG.y) >= contrast(y, DARK_FG.y)
+    ? '#FFFFFF'
+    : linearToHex(oklchToLinear(DARK_FG_OKLCH))
 }
 
 export function normalizeBrandHex(hex: string | undefined | null): string {

--- a/shared/utils/notifications.ts
+++ b/shared/utils/notifications.ts
@@ -16,10 +16,9 @@ export function isActorAdmin(session: OrgListSession, orgId: string): boolean {
   return role === 'owner' || role === 'manager'
 }
 
-// The comment decision table: which event types a new comment fires. Only an
-// admin's top-level comment notifies anyone (official reply → owner + voters).
-// A reply notifies nobody, and neither does an ordinary user's top-level
-// comment — both are deliberate, not gaps.
+// The subscriber-side comment decision table: only an admin's top-level comment
+// notifies subscribers (official reply → owner + voters). A reply or an ordinary
+// user's comment notifies none of them.
 export function resolveCommentEvents(input: { isTopLevel: boolean; authorIsAdmin: boolean }): NotificationTypeKey[] {
   if (!input.isTopLevel) return []
   if (input.authorIsAdmin) return ['post.admin_replied']


### PR DESCRIPTION
## What this PR does

  Adds admin-facing notifications and makes official replies visible as such.

  - **Two new notification events** — `post.created` and `post.user_commented` — resolved from org membership (`owner` + `manager`, minus the
  actor) instead of `post_subscription`.
  - **Notification emails take the org's brand colour** from `organization.metadata`; auth emails stay on the platform colour. Foreground is picked
  by WCAG contrast so the button text stays readable on any brand hex.
  - **Comment replies written by an owner/manager are badged.** The comment endpoint now resolves the org's admins once per request and returns
  `author.isAdmin`.
  - **Feedback filed through the widget emits the same `post.created`** as the web form, so the entry point no longer decides whether the team
  hears about it.
  - **Two fixes** — a freshly posted comment showed no badge, and an edited comment lost its author name, avatar and owner-only menu, until the
  post was reopened.

  ## Why

  `post_subscription` is the right audience for subscriber-facing events, and it deliberately excludes admins — authorship and votes write those
  rows, and staff neither author nor vote. The consequence was that nobody on the team was notified about the two things a board owner most needs
  to see: new feedback arriving, and a user replying. Reaching for the subscription table for these would have meant subscribing admins to every
  post, which changes the meaning of the table.

  Separately, once an admin did reply, the reply rendered identically to any other comment, so an official answer carried no more weight than a
  passing remark.

  ## How to review

  Start with `server/utils/notifications.ts` — `resolveOrgAdminRecipients()` is the entire "who" decision, and `emitAdminNotification()` the
  delivery. Everything else is call sites and templates.

  The two emit sites are `server/api/posts/index.post.ts` and `server/api/posts/[postId]/comments/index.post.ts`, with
  `server/api/widget/messages.post.ts` mirroring the first. That duplication is deliberate: folding the emit into `createPostRecord()` would put
  email delivery inside a DB helper and hide the send condition from the handler. Keeping it at the call site also means `grep
  emitAdminNotification` lists every place mail can go out.

  Worth knowing while reading:

  - **`post.user_commented` fires for replies too**, unlike the subscriber path, which only notifies on an admin's top-level comment. Deliberate — 
  a reply buried under a thread is exactly what a team misses — but it is the one behavioural choice here I would most like a second opinion on.
  - **The merge commit (`e4115b8`) is a plain merge of `main`**, not a rewrite. Two files needed resolution: `server/api/posts/index.post.ts` 
  adopts main's `createPostRecord` / `fetchPostAuthor` extraction while keeping the emit; `shared/utils/branding.ts` keeps main's 
  `pickBrandForegroundHex` and drops this branch's byte-identical `pickHexForeground` plus its duplicated `linearToHex`, with `email-templates.ts` 
  moved onto the surviving helper. `branding.ts` therefore ends up identical to main and shows no net change.
  - **`comments/index.get.ts` lost a `session` guard.** Formatting of eager-loaded child comments used to be gated on a session, so signed-out 
  visitors received raw rows with no author at all. `attachLikeStatus` already handles a missing user, so the guard was doing nothing but breaking 
  logged-out reads.

  Verified locally: `pnpm build` passes. 

  ## Checklist

  - [x] Commits are signed off (`git commit -s`) — all four content commits; the merge commit carries none, which the DCO check skips
  - [x] Tests pass locally (`pnpm build`) — no test suite in the repo; docker build not run
  - [x] If schema changed, migration was generated (`pnpm generate:migration`) and committed — no schema change in this PR
  - [x] If public API or env vars changed, `README.md` / `.env.example` / `docs/deploy/*` updated — no env vars added; `author.isAdmin` is a new 
  additive field on the comment response, undocumented today like the rest of that endpoint
  - [x] No secrets, internal URLs, or team member names in the diff — grepped the full range