### PR TITLE
Feat/feedback filters

### DIFF
--- a/app/components/dashboard/FeedbackQuickFilters.vue
+++ b/app/components/dashboard/FeedbackQuickFilters.vue
@@ -30,7 +30,7 @@ const lit = (field: EnumFilterField, value: string) => railValue(props.condition
 </script>
 
 <template>
-  <aside class="hidden lg:flex w-48 shrink-0 border-r border-border bg-background/30 flex-col gap-5 p-3 overflow-y-auto">
+  <aside class="hidden min-[1160px]:flex w-48 shrink-0 border-r border-border bg-background/30 flex-col gap-5 p-3 overflow-y-auto">
     <div class="flex flex-col gap-0.5">
       <p class="px-2 mb-1 text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
         {{ $t('dashboard.feedback.statuses') }}

--- a/app/components/dashboard/FeedbackQuickFilters.vue
+++ b/app/components/dashboard/FeedbackQuickFilters.vue
@@ -1,0 +1,83 @@
+<script setup lang="ts">
+// Quick-filter rail: writes the same conditions the chip bar holds.
+
+const props = defineProps<{
+  conditions: FilterCondition[]
+  boards: { id: string, name: string }[]
+}>()
+
+const emit = defineEmits<{
+  pick: [field: EnumFilterField, value: string]
+  clear: []
+}>()
+
+const { t } = useI18n()
+
+const boardsOpen = ref(true)
+
+const statuses = computed(() => STATUS_OPTIONS.map(s => ({
+  value: s.value,
+  label: t(statusLabelKey(s.value)),
+  color: s.color,
+})))
+
+const boardEntries = computed(() => [
+  ...props.boards.map(b => ({ value: b.id, label: b.name })),
+  { value: 'none', label: t('dashboard.filter.noBoard') },
+])
+
+const lit = (field: EnumFilterField, value: string) => railValue(props.conditions, field) === value
+</script>
+
+<template>
+  <aside class="hidden lg:flex w-48 shrink-0 border-r border-border bg-background/30 flex-col gap-5 p-3 overflow-y-auto">
+    <div class="flex flex-col gap-0.5">
+      <p class="px-2 mb-1 text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
+        {{ $t('dashboard.feedback.statuses') }}
+      </p>
+      <button
+        v-for="s in statuses"
+        :key="s.value"
+        class="flex items-center gap-2.5 w-full px-2 py-1.5 rounded-lg text-xs font-semibold text-left transition-colors"
+        :class="lit('status', s.value) ? 'bg-secondary text-primary font-bold' : 'text-foreground hover:bg-background'"
+        @click="emit('pick', 'status', s.value)"
+      >
+        <span class="w-2 h-2 rounded-full shrink-0" :style="{ background: s.color }" />
+        <span class="truncate">{{ s.label }}</span>
+      </button>
+
+      <button
+        class="flex items-center gap-2.5 w-full px-2 py-1.5 mt-1 rounded-lg text-xs font-bold text-muted-foreground hover:text-primary transition-colors text-left"
+        @click="emit('clear')"
+      >
+        <Icon name="lucide:rotate-ccw" size="13" class="shrink-0" />
+        <span class="truncate">{{ $t('dashboard.feedback.clearAllFilters') }}</span>
+      </button>
+    </div>
+
+    <div class="flex flex-col gap-0.5">
+      <p class="px-2 mb-1 text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
+        {{ $t('dashboard.feedback.quickFilters') }}
+      </p>
+      <button
+        class="flex items-center gap-2 w-full px-2 py-1 text-[10px] font-bold uppercase tracking-wider text-muted-foreground hover:text-foreground transition-colors"
+        @click="boardsOpen = !boardsOpen"
+      >
+        <Icon :name="boardsOpen ? 'lucide:chevron-down' : 'lucide:chevron-right'" size="12" class="shrink-0" />
+        {{ $t('dashboard.filter.board') }}
+      </button>
+      <div v-if="boardsOpen" class="ml-3 pl-2 border-l border-border flex flex-col gap-0.5">
+        <button
+          v-for="b in boardEntries"
+          :key="b.value"
+          class="flex items-center gap-2.5 w-full px-2 py-1.5 rounded-lg text-xs font-semibold text-left transition-colors"
+          :class="lit('boardId', b.value) ? 'bg-secondary text-primary font-bold' : 'text-foreground hover:bg-background'"
+          @click="emit('pick', 'boardId', b.value)"
+        >
+          <Icon name="lucide:layers" size="13" class="shrink-0 opacity-60" />
+          <span class="truncate">{{ b.label }}</span>
+        </button>
+      </div>
+    </div>
+  </aside>
+</template>

--- a/app/components/shared/FilterChip.vue
+++ b/app/components/shared/FilterChip.vue
@@ -2,13 +2,7 @@
 // Three-segment filter chip: field | operator | value(s) | ×
 // The `single` kind has no operator segment.
 
-export interface FilterChipOption {
-  value: string
-  label: string
-  sub?: string
-  color?: string
-  image?: string | null
-}
+import type { FilterValueOption } from './FilterValuePanel.vue'
 
 const props = withDefaults(defineProps<{
   label: string
@@ -18,7 +12,7 @@ const props = withDefaults(defineProps<{
   values?: string[]
   from?: string
   to?: string
-  options?: FilterChipOption[]
+  options?: FilterValueOption[]
   searchable?: boolean
 }>(), {
   values: () => [],
@@ -64,40 +58,6 @@ const valueLabel = computed(() => {
 })
 
 const extraCount = computed(() => (props.kind === 'date' ? 0 : Math.max(0, props.values.length - 1)))
-
-const search = ref('')
-const showSearch = computed(() => props.searchable || props.options.length > 8)
-const visibleOptions = computed(() => {
-  const kw = search.value.trim().toLowerCase()
-  if (!kw) return props.options
-  return props.options.filter(o =>
-    o.label.toLowerCase().includes(kw) || (o.sub || '').toLowerCase().includes(kw))
-})
-
-function toggleValue(value: string) {
-  if (props.kind === 'single') {
-    emit('update:values', [value])
-    return
-  }
-  const next = props.values.includes(value)
-    ? props.values.filter(v => v !== value)
-    : [...props.values, value]
-  emit('update:values', next)
-}
-
-function quickRange(days: number | 'quarter') {
-  const now = new Date()
-  const iso = (d: Date) => `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
-  const start = days === 'quarter'
-    ? new Date(now.getFullYear(), Math.floor(now.getMonth() / 3) * 3, 1)
-    : new Date(now.getFullYear(), now.getMonth(), now.getDate() - days)
-  emit('update:op', 'range')
-  emit('update:range', { from: iso(start), to: iso(now) })
-}
-
-function initials(name: string) {
-  return name.slice(0, 2).toUpperCase()
-}
 </script>
 
 <template>
@@ -145,72 +105,18 @@ function initials(name: string) {
       </DropdownMenuTrigger>
 
       <DropdownMenuContent align="start" class="min-w-[200px] max-w-[320px]">
-        <template v-if="kind === 'date'">
-          <div class="flex flex-wrap gap-1.5 p-1.5">
-            <button
-              v-for="[key, days] in ([['last7', 7], ['last30', 30], ['thisQuarter', 'quarter']] as const)"
-              :key="key"
-              class="text-[10px] font-bold px-2 py-1 rounded-md border border-border text-muted-foreground hover:text-primary hover:border-primary transition-colors"
-              @click="quickRange(days)"
-            >
-              {{ $t(`dashboard.filter.${key}`) }}
-            </button>
-          </div>
-          <div class="flex items-center gap-1.5 p-1.5 pt-0">
-            <input
-              v-if="op !== 'before'"
-              type="date"
-              :value="from || ''"
-              class="flex-1 h-7 px-1.5 rounded-md border border-border bg-background text-[11px]"
-              @input="emit('update:range', { from: ($event.target as HTMLInputElement).value || undefined, to })"
-            >
-            <span v-if="op === 'range'" class="text-[10px] text-muted-foreground">–</span>
-            <input
-              v-if="op !== 'after'"
-              type="date"
-              :value="to || ''"
-              class="flex-1 h-7 px-1.5 rounded-md border border-border bg-background text-[11px]"
-              @input="emit('update:range', { from, to: ($event.target as HTMLInputElement).value || undefined })"
-            >
-          </div>
-        </template>
-
-        <template v-else>
-          <div v-if="showSearch" class="p-1.5 pb-1">
-            <input
-              v-model="search"
-              class="w-full h-7 px-2 rounded-md border border-border bg-background text-[11px]"
-              :placeholder="$t('dashboard.filter.searchPlaceholder')"
-            >
-          </div>
-          <div class="max-h-[240px] overflow-y-auto">
-            <DropdownMenuItem
-              v-for="opt in visibleOptions"
-              :key="opt.value"
-              class="cursor-pointer text-xs gap-2"
-              @select.prevent="toggleValue(opt.value)"
-            >
-              <span
-                class="w-3.5 h-3.5 shrink-0 rounded border flex items-center justify-center"
-                :class="values.includes(opt.value) ? 'bg-primary border-primary text-primary-foreground' : 'border-border'"
-              >
-                <Icon v-if="values.includes(opt.value)" name="lucide:check" size="10" />
-              </span>
-              <span v-if="opt.color" class="w-2 h-2 rounded-full shrink-0" :style="{ background: opt.color }" />
-              <Avatar v-else-if="opt.sub !== undefined" class="w-5 h-5 shrink-0">
-                <img v-if="opt.image" :src="opt.image" :alt="opt.label" class="aspect-square size-full rounded-full object-cover" referrerpolicy="no-referrer">
-                <AvatarFallback v-else class="bg-accent text-accent-foreground text-[8px] font-bold">
-                  {{ initials(opt.label) }}
-                </AvatarFallback>
-              </Avatar>
-              <span class="truncate">{{ opt.label }}</span>
-              <span v-if="opt.sub" class="ml-auto pl-2 text-[10px] text-muted-foreground truncate">{{ opt.sub }}</span>
-            </DropdownMenuItem>
-            <p v-if="!visibleOptions.length" class="px-2 py-3 text-center text-[11px] text-muted-foreground">
-              {{ $t('dashboard.filter.noMatches') }}
-            </p>
-          </div>
-        </template>
+        <FilterValuePanel
+          :kind="kind"
+          :op="op"
+          :values="values"
+          :from="from"
+          :to="to"
+          :options="options"
+          :searchable="searchable"
+          @update:op="emit('update:op', $event)"
+          @update:values="emit('update:values', $event)"
+          @update:range="emit('update:range', $event)"
+        />
       </DropdownMenuContent>
     </DropdownMenu>
 

--- a/app/components/shared/FilterChip.vue
+++ b/app/components/shared/FilterChip.vue
@@ -45,14 +45,22 @@ const OPS: Record<string, string[]> = {
 
 const opLabel = (op: string) => t(`dashboard.filter.op.${op}`)
 
+const firstKnown = computed(() => props.values.map(v => props.options.find(o => o.value === v)).find(Boolean))
+
+// The option-list guard matters: candidates load async, and nothing resolves until they do.
+const isStale = computed(() => props.kind !== 'date'
+  && props.values.length > 0
+  && props.options.length > 0
+  && !firstKnown.value)
+
 const valueLabel = computed(() => {
   if (props.kind === 'date') {
     if (props.op === 'range') return `${props.from || '…'} – ${props.to || '…'}`
     return props.from || props.to || t('dashboard.filter.pickDate')
   }
   if (!props.values.length) return t('dashboard.filter.pickValue')
-  const first = props.options.find(o => o.value === props.values[0])
-  return first?.label ?? props.values[0]!
+  if (isStale.value) return t('dashboard.filter.staleValue')
+  return firstKnown.value?.label ?? props.values[0]!
 })
 
 const extraCount = computed(() => (props.kind === 'date' ? 0 : Math.max(0, props.values.length - 1)))
@@ -126,7 +134,10 @@ function initials(name: string) {
 
     <DropdownMenu>
       <DropdownMenuTrigger as-child>
-        <button class="px-2.5 py-1 text-primary text-[10px] font-bold flex items-center gap-1 hover:bg-background/50 transition-colors cursor-pointer whitespace-nowrap">
+        <button
+          class="px-2.5 py-1 text-[10px] font-bold flex items-center gap-1 hover:bg-background/50 transition-colors cursor-pointer whitespace-nowrap"
+          :class="isStale ? 'text-muted-foreground italic' : 'text-primary'"
+        >
           {{ valueLabel }}
           <span v-if="extraCount" class="text-muted-foreground font-semibold">+{{ extraCount }}</span>
           <Icon name="lucide:chevron-down" size="10" />

--- a/app/components/shared/FilterChip.vue
+++ b/app/components/shared/FilterChip.vue
@@ -1,0 +1,213 @@
+<script setup lang="ts">
+// Three-segment filter chip: field | operator | value(s) | ×
+// The `single` kind has no operator segment.
+
+export interface FilterChipOption {
+  value: string
+  label: string
+  sub?: string
+  color?: string
+  image?: string | null
+}
+
+const props = withDefaults(defineProps<{
+  label: string
+  icon: string
+  kind: 'enum' | 'date' | 'single'
+  op: string
+  values?: string[]
+  from?: string
+  to?: string
+  options?: FilterChipOption[]
+  searchable?: boolean
+}>(), {
+  values: () => [],
+  options: () => [],
+  from: undefined,
+  to: undefined,
+  searchable: false,
+})
+
+const emit = defineEmits<{
+  'update:op': [op: string]
+  'update:values': [values: string[]]
+  'update:range': [range: { from?: string, to?: string }]
+  'remove': []
+}>()
+
+const { t } = useI18n()
+
+const OPS: Record<string, string[]> = {
+  enum: ['is', 'not'],
+  date: ['after', 'before', 'range'],
+  single: [],
+}
+
+const opLabel = (op: string) => t(`dashboard.filter.op.${op}`)
+
+const valueLabel = computed(() => {
+  if (props.kind === 'date') {
+    if (props.op === 'range') return `${props.from || '…'} – ${props.to || '…'}`
+    return props.from || props.to || t('dashboard.filter.pickDate')
+  }
+  if (!props.values.length) return t('dashboard.filter.pickValue')
+  const first = props.options.find(o => o.value === props.values[0])
+  return first?.label ?? props.values[0]!
+})
+
+const extraCount = computed(() => (props.kind === 'date' ? 0 : Math.max(0, props.values.length - 1)))
+
+const search = ref('')
+const showSearch = computed(() => props.searchable || props.options.length > 8)
+const visibleOptions = computed(() => {
+  const kw = search.value.trim().toLowerCase()
+  if (!kw) return props.options
+  return props.options.filter(o =>
+    o.label.toLowerCase().includes(kw) || (o.sub || '').toLowerCase().includes(kw))
+})
+
+function toggleValue(value: string) {
+  if (props.kind === 'single') {
+    emit('update:values', [value])
+    return
+  }
+  const next = props.values.includes(value)
+    ? props.values.filter(v => v !== value)
+    : [...props.values, value]
+  emit('update:values', next)
+}
+
+function quickRange(days: number | 'quarter') {
+  const now = new Date()
+  const iso = (d: Date) => `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+  const start = days === 'quarter'
+    ? new Date(now.getFullYear(), Math.floor(now.getMonth() / 3) * 3, 1)
+    : new Date(now.getFullYear(), now.getMonth(), now.getDate() - days)
+  emit('update:op', 'range')
+  emit('update:range', { from: iso(start), to: iso(now) })
+}
+
+function initials(name: string) {
+  return name.slice(0, 2).toUpperCase()
+}
+</script>
+
+<template>
+  <div class="inline-flex shrink-0 items-center border border-border rounded-lg overflow-hidden h-7 bg-card">
+    <span class="px-2.5 py-1 bg-background text-[10px] font-bold text-muted-foreground border-r border-border flex items-center gap-1.5 whitespace-nowrap">
+      <Icon :name="icon" size="14" />
+      {{ label }}
+    </span>
+
+    <DropdownMenu v-if="kind !== 'single'">
+      <DropdownMenuTrigger as-child>
+        <button
+          class="px-2.5 py-1 text-[10px] font-bold border-r border-border hover:bg-background/50 transition-colors cursor-pointer whitespace-nowrap"
+          :class="op === 'not' ? 'text-primary' : 'text-muted-foreground'"
+        >
+          {{ opLabel(op) }}
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" class="min-w-[120px]">
+        <DropdownMenuItem
+          v-for="o in OPS[kind]"
+          :key="o"
+          class="cursor-pointer text-xs"
+          :class="o === op ? 'text-primary font-bold' : ''"
+          @select="emit('update:op', o)"
+        >
+          <span class="w-4 shrink-0 flex items-center justify-center">
+            <Icon v-if="o === op" name="lucide:check" size="12" />
+          </span>
+          {{ opLabel(o) }}
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+
+    <DropdownMenu>
+      <DropdownMenuTrigger as-child>
+        <button class="px-2.5 py-1 text-primary text-[10px] font-bold flex items-center gap-1 hover:bg-background/50 transition-colors cursor-pointer whitespace-nowrap">
+          {{ valueLabel }}
+          <span v-if="extraCount" class="text-muted-foreground font-semibold">+{{ extraCount }}</span>
+          <Icon name="lucide:chevron-down" size="10" />
+        </button>
+      </DropdownMenuTrigger>
+
+      <DropdownMenuContent align="start" class="min-w-[200px] max-w-[320px]">
+        <template v-if="kind === 'date'">
+          <div class="flex flex-wrap gap-1.5 p-1.5">
+            <button
+              v-for="[key, days] in ([['last7', 7], ['last30', 30], ['thisQuarter', 'quarter']] as const)"
+              :key="key"
+              class="text-[10px] font-bold px-2 py-1 rounded-md border border-border text-muted-foreground hover:text-primary hover:border-primary transition-colors"
+              @click="quickRange(days)"
+            >
+              {{ $t(`dashboard.filter.${key}`) }}
+            </button>
+          </div>
+          <div class="flex items-center gap-1.5 p-1.5 pt-0">
+            <input
+              v-if="op !== 'before'"
+              type="date"
+              :value="from || ''"
+              class="flex-1 h-7 px-1.5 rounded-md border border-border bg-background text-[11px]"
+              @input="emit('update:range', { from: ($event.target as HTMLInputElement).value || undefined, to })"
+            >
+            <span v-if="op === 'range'" class="text-[10px] text-muted-foreground">–</span>
+            <input
+              v-if="op !== 'after'"
+              type="date"
+              :value="to || ''"
+              class="flex-1 h-7 px-1.5 rounded-md border border-border bg-background text-[11px]"
+              @input="emit('update:range', { from, to: ($event.target as HTMLInputElement).value || undefined })"
+            >
+          </div>
+        </template>
+
+        <template v-else>
+          <div v-if="showSearch" class="p-1.5 pb-1">
+            <input
+              v-model="search"
+              class="w-full h-7 px-2 rounded-md border border-border bg-background text-[11px]"
+              :placeholder="$t('dashboard.filter.searchPlaceholder')"
+            >
+          </div>
+          <div class="max-h-[240px] overflow-y-auto">
+            <DropdownMenuItem
+              v-for="opt in visibleOptions"
+              :key="opt.value"
+              class="cursor-pointer text-xs gap-2"
+              @select.prevent="toggleValue(opt.value)"
+            >
+              <span
+                class="w-3.5 h-3.5 shrink-0 rounded border flex items-center justify-center"
+                :class="values.includes(opt.value) ? 'bg-primary border-primary text-primary-foreground' : 'border-border'"
+              >
+                <Icon v-if="values.includes(opt.value)" name="lucide:check" size="10" />
+              </span>
+              <span v-if="opt.color" class="w-2 h-2 rounded-full shrink-0" :style="{ background: opt.color }" />
+              <Avatar v-else-if="opt.sub !== undefined" class="w-5 h-5 shrink-0">
+                <img v-if="opt.image" :src="opt.image" :alt="opt.label" class="aspect-square size-full rounded-full object-cover" referrerpolicy="no-referrer">
+                <AvatarFallback v-else class="bg-accent text-accent-foreground text-[8px] font-bold">
+                  {{ initials(opt.label) }}
+                </AvatarFallback>
+              </Avatar>
+              <span class="truncate">{{ opt.label }}</span>
+              <span v-if="opt.sub" class="ml-auto pl-2 text-[10px] text-muted-foreground truncate">{{ opt.sub }}</span>
+            </DropdownMenuItem>
+            <p v-if="!visibleOptions.length" class="px-2 py-3 text-center text-[11px] text-muted-foreground">
+              {{ $t('dashboard.filter.noMatches') }}
+            </p>
+          </div>
+        </template>
+      </DropdownMenuContent>
+    </DropdownMenu>
+
+    <button
+      class="px-1.5 py-1 text-muted-foreground hover:text-foreground transition-colors border-l border-border"
+      @click="emit('remove')"
+    >
+      <Icon name="lucide:x" size="12" />
+    </button>
+  </div>
+</template>

--- a/app/components/shared/FilterValuePanel.vue
+++ b/app/components/shared/FilterValuePanel.vue
@@ -1,0 +1,137 @@
+<script setup lang="ts">
+// Value picker shared by the filter chip and the Filters menu's second level.
+// Renders menu content only — the caller supplies the DropdownMenuContent wrapper.
+
+export interface FilterValueOption {
+  value: string
+  label: string
+  sub?: string
+  color?: string
+  image?: string | null
+}
+
+const props = withDefaults(defineProps<{
+  kind: 'enum' | 'date' | 'single'
+  op: string
+  values?: string[]
+  from?: string
+  to?: string
+  options?: FilterValueOption[]
+  searchable?: boolean
+}>(), {
+  values: () => [],
+  options: () => [],
+  from: undefined,
+  to: undefined,
+  searchable: false,
+})
+
+const emit = defineEmits<{
+  'update:op': [op: string]
+  'update:values': [values: string[]]
+  'update:range': [range: { from?: string, to?: string }]
+}>()
+
+const search = ref('')
+const showSearch = computed(() => props.searchable || props.options.length > 8)
+const visibleOptions = computed(() => {
+  const kw = search.value.trim().toLowerCase()
+  if (!kw) return props.options
+  return props.options.filter(o =>
+    o.label.toLowerCase().includes(kw) || (o.sub || '').toLowerCase().includes(kw))
+})
+
+function toggleValue(value: string) {
+  if (props.kind === 'single') {
+    emit('update:values', [value])
+    return
+  }
+  const next = props.values.includes(value)
+    ? props.values.filter(v => v !== value)
+    : [...props.values, value]
+  emit('update:values', next)
+}
+
+function quickRange(days: number | 'quarter') {
+  const now = new Date()
+  const iso = (d: Date) => `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+  const start = days === 'quarter'
+    ? new Date(now.getFullYear(), Math.floor(now.getMonth() / 3) * 3, 1)
+    : new Date(now.getFullYear(), now.getMonth(), now.getDate() - days)
+  emit('update:op', 'range')
+  emit('update:range', { from: iso(start), to: iso(now) })
+}
+
+function initials(name: string) {
+  return name.slice(0, 2).toUpperCase()
+}
+</script>
+
+<template>
+  <template v-if="kind === 'date'">
+    <div class="flex flex-wrap gap-1.5 p-1.5">
+      <button
+        v-for="[key, days] in ([['last7', 7], ['last30', 30], ['thisQuarter', 'quarter']] as const)"
+        :key="key"
+        class="text-[10px] font-bold px-2 py-1 rounded-md border border-border text-muted-foreground hover:text-primary hover:border-primary transition-colors"
+        @click="quickRange(days)"
+      >
+        {{ $t(`dashboard.filter.${key}`) }}
+      </button>
+    </div>
+    <div class="flex items-center gap-1.5 p-1.5 pt-0">
+      <input
+        v-if="op !== 'before'"
+        type="date"
+        :value="from || ''"
+        class="flex-1 h-7 px-1.5 rounded-md border border-border bg-background text-[11px]"
+        @input="emit('update:range', { from: ($event.target as HTMLInputElement).value || undefined, to })"
+      >
+      <span v-if="op === 'range'" class="text-[10px] text-muted-foreground">–</span>
+      <input
+        v-if="op !== 'after'"
+        type="date"
+        :value="to || ''"
+        class="flex-1 h-7 px-1.5 rounded-md border border-border bg-background text-[11px]"
+        @input="emit('update:range', { from, to: ($event.target as HTMLInputElement).value || undefined })"
+      >
+    </div>
+  </template>
+
+  <template v-else>
+    <div v-if="showSearch" class="p-1.5 pb-1">
+      <input
+        v-model="search"
+        class="w-full h-7 px-2 rounded-md border border-border bg-background text-[11px]"
+        :placeholder="$t('dashboard.filter.searchPlaceholder')"
+      >
+    </div>
+    <div class="max-h-[240px] overflow-y-auto">
+      <DropdownMenuItem
+        v-for="opt in visibleOptions"
+        :key="opt.value"
+        class="cursor-pointer text-xs gap-2"
+        @select.prevent="toggleValue(opt.value)"
+      >
+        <span
+          class="w-3.5 h-3.5 shrink-0 rounded border flex items-center justify-center"
+          :class="values.includes(opt.value) ? 'bg-primary border-primary text-primary-foreground' : 'border-border'"
+        >
+          <Icon v-if="values.includes(opt.value)" name="lucide:check" size="10" />
+        </span>
+        <span v-if="opt.color" class="w-2 h-2 rounded-full shrink-0" :style="{ background: opt.color }" />
+        <Avatar v-else-if="opt.sub !== undefined" class="w-5 h-5 shrink-0">
+          <img v-if="opt.image" :src="opt.image" :alt="opt.label" class="aspect-square size-full rounded-full object-cover" referrerpolicy="no-referrer">
+          <AvatarFallback v-else class="bg-accent text-accent-foreground text-[8px] font-bold">
+            {{ initials(opt.label) }}
+          </AvatarFallback>
+        </Avatar>
+        <span class="truncate">{{ opt.label }}</span>
+        <span v-if="opt.sub" class="ml-auto pl-2 text-[10px] text-muted-foreground truncate">{{ opt.sub }}</span>
+      </DropdownMenuItem>
+      <p v-if="!visibleOptions.length" class="px-2 py-3 text-center text-[11px] text-muted-foreground">
+        {{ $t('dashboard.filter.noMatches') }}
+      </p>
+    </div>
+  </template>
+</template>

--- a/app/composables/useFeedbackFilters.ts
+++ b/app/composables/useFeedbackFilters.ts
@@ -49,7 +49,7 @@ export function parseFilterQuery(query: Record<string, unknown>): FilterConditio
 // parameter name and leaves `status%21=open` in the address bar.
 export function serializeFilterQuery(
   conditions: FilterCondition[],
-  extra: { q?: string, sort?: string, page?: number } = {},
+  extra: { q?: string, sort?: string, order?: string, page?: number } = {},
 ): string {
   const parts: string[] = []
 
@@ -69,6 +69,7 @@ export function serializeFilterQuery(
   }
 
   if (extra.sort && extra.sort !== 'createdAt') parts.push(`sort=${extra.sort}`)
+  if (extra.order === 'asc') parts.push('order=asc')
   if (extra.page && extra.page > 1) parts.push(`page=${extra.page}`)
 
   return parts.join('&')
@@ -83,7 +84,7 @@ function dayBoundary(date: string, plusDays = 0): string | undefined {
 
 export function filterApiQuery(
   conditions: FilterCondition[],
-  extra: { q?: string, sort?: string, page?: number, pageSize?: number } = {},
+  extra: { q?: string, sort?: string, order?: string, page?: number, pageSize?: number } = {},
 ): Record<string, string | number | undefined> {
   const query: Record<string, string | number | undefined> = { merged: 'canonical_only', ...extra }
 

--- a/app/composables/useFeedbackFilters.ts
+++ b/app/composables/useFeedbackFilters.ts
@@ -1,0 +1,123 @@
+// The one copy of the admin feedback filter conditions: the chip bar, the
+// quick-filter rail and the address bar all read and write this shape.
+
+export type EnumFilterField = 'status' | 'boardId' | 'author'
+
+export type FilterCondition =
+  | { field: EnumFilterField, op: 'is' | 'not', values: string[] }
+  | { field: 'created', op: 'before' | 'after' | 'range', from?: string, to?: string }
+  | { field: 'merged', value: string }
+
+const ENUM_FIELDS: EnumFilterField[] = ['status', 'boardId', 'author']
+
+function str(v: unknown): string | undefined {
+  return typeof v === 'string' && v ? v : undefined
+}
+
+function list(v: unknown): string[] | undefined {
+  const s = str(v)
+  if (!s) return undefined
+  const items = s.split(',').map(x => x.trim()).filter(Boolean)
+  return items.length ? items : undefined
+}
+
+export function parseFilterQuery(query: Record<string, unknown>): FilterCondition[] {
+  const conditions: FilterCondition[] = []
+
+  for (const field of ENUM_FIELDS) {
+    const not = list(query[`${field}!`])
+    if (not) conditions.push({ field, op: 'not', values: not })
+    else {
+      const is = list(query[field])
+      if (is) conditions.push({ field, op: 'is', values: is })
+    }
+  }
+
+  const from = str(query.createdFrom)
+  const to = str(query.createdTo)
+  if (from || to) {
+    conditions.push({ field: 'created', op: from && to ? 'range' : from ? 'after' : 'before', from, to })
+  }
+
+  const merged = str(query.merged)
+  if (merged && merged !== 'canonical_only') conditions.push({ field: 'merged', value: merged })
+
+  return conditions
+}
+
+// Hand-rolled instead of URLSearchParams, which percent-encodes the `!` in a
+// parameter name and leaves `status%21=open` in the address bar.
+export function serializeFilterQuery(
+  conditions: FilterCondition[],
+  extra: { q?: string, sort?: string, page?: number } = {},
+): string {
+  const parts: string[] = []
+
+  if (extra.q) parts.push(`q=${encodeURIComponent(extra.q)}`)
+
+  for (const c of conditions) {
+    if (c.field === 'created') {
+      if (c.op !== 'before' && c.from) parts.push(`createdFrom=${c.from}`)
+      if (c.op !== 'after' && c.to) parts.push(`createdTo=${c.to}`)
+    }
+    else if (c.field === 'merged') {
+      if (c.value !== 'canonical_only') parts.push(`merged=${c.value}`)
+    }
+    else if (c.values.length) {
+      parts.push(`${c.field}${c.op === 'not' ? '!' : ''}=${c.values.map(encodeURIComponent).join(',')}`)
+    }
+  }
+
+  if (extra.sort && extra.sort !== 'createdAt') parts.push(`sort=${extra.sort}`)
+  if (extra.page && extra.page > 1) parts.push(`page=${extra.page}`)
+
+  return parts.join('&')
+}
+
+// `to` is exclusive: the boundary is the day after, in the browser's timezone.
+function dayBoundary(date: string, plusDays = 0): string | undefined {
+  const [y, m, d] = date.split('-').map(Number)
+  if (!y || !m || !d) return undefined
+  return new Date(y, m - 1, d + plusDays).toISOString()
+}
+
+export function filterApiQuery(
+  conditions: FilterCondition[],
+  extra: { q?: string, sort?: string, page?: number, pageSize?: number } = {},
+): Record<string, string | number | undefined> {
+  const query: Record<string, string | number | undefined> = { merged: 'canonical_only', ...extra }
+
+  for (const c of conditions) {
+    if (c.field === 'created') {
+      if (c.op !== 'before' && c.from) query.createdFrom = dayBoundary(c.from)
+      if (c.op !== 'after' && c.to) query.createdTo = dayBoundary(c.to, 1)
+    }
+    else if (c.field === 'merged') {
+      query.merged = c.value
+    }
+    else if (c.values.length) {
+      query[`${c.field}${c.op === 'not' ? '!' : ''}`] = c.values.join(',')
+    }
+  }
+
+  return query
+}
+
+export function findCondition(conditions: FilterCondition[], field: string): FilterCondition | undefined {
+  return conditions.find(c => c.field === field)
+}
+
+export function railValue(conditions: FilterCondition[], field: EnumFilterField): string | null {
+  const c = findCondition(conditions, field)
+  if (!c || c.field === 'created' || c.field === 'merged') return null
+  return c.op === 'is' && c.values.length === 1 ? c.values[0]! : null
+}
+
+export function toggleRail(
+  conditions: FilterCondition[],
+  field: EnumFilterField,
+  value: string,
+): FilterCondition[] {
+  if (railValue(conditions, field) === value) return conditions.filter(c => c.field !== field)
+  return [...conditions.filter(c => c.field !== field), { field, op: 'is', values: [value] }]
+}

--- a/app/layouts/dashboard.vue
+++ b/app/layouts/dashboard.vue
@@ -187,42 +187,46 @@ const developerOpen = ref(developerNav.value.some(item => route.path.startsWith(
     </Sheet>
 
     <!-- Desktop Sidebar -->
-    <aside class="hidden md:flex w-[260px] h-full shrink-0 border-r border-border bg-card flex-col">
-      <DashboardSidebarBrand />
-      <DashboardSidebarTop />
+    <aside class="hidden md:flex w-16 min-[1360px]:w-[260px] h-full shrink-0 border-r border-border bg-card flex-col">
+      <div class="hidden min-[1360px]:block">
+        <DashboardSidebarBrand />
+        <DashboardSidebarTop />
+      </div>
 
       <!-- Navigation -->
-      <nav class="flex-1 px-4 space-y-8 overflow-y-auto">
+      <nav class="flex-1 px-2 min-[1360px]:px-4 pt-4 min-[1360px]:pt-0 space-y-8 overflow-y-auto">
         <!-- Main -->
         <div>
-          <p class="px-3 mb-2 text-[11px] font-bold uppercase tracking-wider text-muted-foreground">{{ $t('dashboard.nav.main') }}</p>
+          <p class="hidden min-[1360px]:block px-3 mb-2 text-[11px] font-bold uppercase tracking-wider text-muted-foreground">{{ $t('dashboard.nav.main') }}</p>
           <div class="space-y-1">
             <NuxtLink
               v-for="item in mainNav"
               :key="item.to"
               :to="localePath(item.to)"
-              class="flex items-center gap-3 px-3 py-2 rounded-lg text-muted-foreground hover:bg-background hover:text-foreground transition-colors font-semibold"
+              class="flex items-center gap-3 py-2 rounded-lg justify-center min-[1360px]:justify-start px-0 min-[1360px]:px-3 text-muted-foreground hover:bg-background hover:text-foreground transition-colors font-semibold"
+              :title="item.label"
               active-class="!bg-secondary !text-primary !font-bold"
             >
-              <Icon :name="item.icon" size="20" />
-              <span class="text-sm">{{ item.label }}</span>
+              <Icon :name="item.icon" size="20" class="shrink-0" />
+              <span class="hidden min-[1360px]:inline text-sm">{{ item.label }}</span>
             </NuxtLink>
           </div>
         </div>
 
         <!-- Settings -->
         <div>
-          <p class="px-3 mb-2 text-[11px] font-bold uppercase tracking-wider text-muted-foreground">{{ $t('dashboard.nav.settings') }}</p>
+          <p class="hidden min-[1360px]:block px-3 mb-2 text-[11px] font-bold uppercase tracking-wider text-muted-foreground">{{ $t('dashboard.nav.settings') }}</p>
           <div class="space-y-1">
             <NuxtLink
               v-for="item in settingsNav"
               :key="item.to"
               :to="localePath(item.to)"
-              class="flex items-center gap-3 px-3 py-2 rounded-lg text-muted-foreground hover:bg-background hover:text-foreground transition-colors font-semibold"
+              class="flex items-center gap-3 py-2 rounded-lg justify-center min-[1360px]:justify-start px-0 min-[1360px]:px-3 text-muted-foreground hover:bg-background hover:text-foreground transition-colors font-semibold"
+              :title="item.label"
               active-class="!bg-secondary !text-primary !font-bold"
             >
-              <Icon :name="item.icon" size="20" />
-              <span class="text-sm">{{ item.label }}</span>
+              <Icon :name="item.icon" size="20" class="shrink-0" />
+              <span class="hidden min-[1360px]:inline text-sm">{{ item.label }}</span>
             </NuxtLink>
           </div>
         </div>
@@ -230,7 +234,7 @@ const developerOpen = ref(developerNav.value.some(item => route.path.startsWith(
         <!-- Developer (collapsible, collapsed by default) -->
         <div v-if="developerNav.length">
           <button
-            class="w-full flex items-center justify-between px-3 mb-2 group"
+            class="hidden min-[1360px]:flex w-full items-center justify-between px-3 mb-2 group"
             @click="developerOpen = !developerOpen"
           >
             <span class="text-[11px] font-bold uppercase tracking-wider text-muted-foreground group-hover:text-foreground transition-colors">{{ $t('dashboard.nav.developer') }}</span>
@@ -240,37 +244,41 @@ const developerOpen = ref(developerNav.value.some(item => route.path.startsWith(
               class="text-muted-foreground"
             />
           </button>
-          <div v-show="developerOpen" class="space-y-1">
+          <div class="space-y-1" :class="developerOpen ? '' : 'min-[1360px]:hidden'">
             <NuxtLink
               v-for="item in developerNav"
               :key="item.to"
               :to="localePath(item.to)"
-              class="flex items-center gap-3 px-3 py-2 rounded-lg text-muted-foreground hover:bg-background hover:text-foreground transition-colors font-semibold"
+              class="flex items-center gap-3 py-2 rounded-lg justify-center min-[1360px]:justify-start px-0 min-[1360px]:px-3 text-muted-foreground hover:bg-background hover:text-foreground transition-colors font-semibold"
+              :title="item.label"
               active-class="!bg-secondary !text-primary !font-bold"
             >
-              <Icon :name="item.icon" size="20" />
-              <span class="text-sm">{{ item.label }}</span>
+              <Icon :name="item.icon" size="20" class="shrink-0" />
+              <span class="hidden min-[1360px]:inline text-sm">{{ item.label }}</span>
             </NuxtLink>
           </div>
         </div>
       </nav>
 
       <!-- User info (bottom) -->
-      <div class="h-16 px-4 border-t border-border flex items-center gap-1">
+      <div class="border-t border-border flex items-center flex-col min-[1360px]:flex-row gap-1 py-3 min-[1360px]:py-0 px-1 min-[1360px]:px-4 min-[1360px]:h-16">
         <DropdownMenu>
           <DropdownMenuTrigger as-child>
-            <button class="flex items-center gap-3 flex-1 min-w-0 p-2 rounded-xl hover:bg-background transition-colors">
+            <button class="flex items-center gap-3 rounded-xl hover:bg-background transition-colors p-1.5 min-[1360px]:flex-1 min-[1360px]:min-w-0 min-[1360px]:p-2">
               <Avatar class="w-8 h-8 shrink-0">
                 <img v-if="user?.image && !avatarError" :src="user.image" :alt="user?.name" class="aspect-square size-full rounded-full object-cover" referrerpolicy="no-referrer" @error="avatarError = true">
                 <AvatarFallback v-else class="bg-accent text-accent-foreground text-sm font-bold">
                   {{ initials }}
                 </AvatarFallback>
               </Avatar>
-              <div class="flex-1 text-left">
+              <div class="hidden min-[1360px]:block flex-1 text-left">
                 <p class="text-xs font-bold truncate">{{ user?.name }}</p>
                 <p class="text-[10px] text-muted-foreground truncate">{{ user?.email }}</p>
               </div>
-              <Icon name="lucide:chevron-up" size="16" class="text-muted-foreground" />
+              <!-- Wrapper needed: .iconify wins over .hidden, so display classes on <Icon> do nothing. -->
+              <span class="hidden min-[1360px]:block">
+                <Icon name="lucide:chevron-up" size="16" class="text-muted-foreground" />
+              </span>
             </button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="start" side="top" class="w-[228px]">

--- a/app/layouts/dashboard.vue
+++ b/app/layouts/dashboard.vue
@@ -275,10 +275,6 @@ const developerOpen = ref(developerNav.value.some(item => route.path.startsWith(
                 <p class="text-xs font-bold truncate">{{ user?.name }}</p>
                 <p class="text-[10px] text-muted-foreground truncate">{{ user?.email }}</p>
               </div>
-              <!-- Wrapper needed: .iconify wins over .hidden, so display classes on <Icon> do nothing. -->
-              <span class="hidden min-[1360px]:block">
-                <Icon name="lucide:chevron-up" size="16" class="text-muted-foreground" />
-              </span>
             </button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="start" side="top" class="w-[228px]">

--- a/app/pages/dashboard/feedback.vue
+++ b/app/pages/dashboard/feedback.vue
@@ -64,6 +64,20 @@ function addCondition(key: FieldKey) {
   conditions.value = [...conditions.value, created]
 }
 
+const pickingField = ref<FieldKey | null>(null)
+
+const picking = computed(() => {
+  if (!pickingField.value) return null
+  const def = fieldDefs.value.find(d => d.key === pickingField.value)
+  const condition = conditions.value.find(c => c.field === pickingField.value)
+  return def && condition ? { def, condition } : null
+})
+
+function startPicking(key: FieldKey) {
+  addCondition(key)
+  pickingField.value = key
+}
+
 function patchCondition(field: string, patch: Record<string, unknown>) {
   conditions.value = conditions.value.map(c => (c.field === field ? { ...c, ...patch } as FilterCondition : c))
 }
@@ -211,7 +225,7 @@ function onPostDeleted(postId: string) {
       <AdminFeedbackSearch v-model="searchTerm" />
 
       <!-- Filters button -->
-      <DropdownMenu v-model:open="addFilterOpen">
+      <DropdownMenu v-model:open="addFilterOpen" @update:open="pickingField = null">
         <DropdownMenuTrigger as-child>
           <button
             class="h-9 px-3 rounded-lg border border-border bg-background text-xs font-heading font-bold text-muted-foreground hover:text-foreground hover:border-primary transition-all flex items-center gap-2"
@@ -220,19 +234,42 @@ function onPostDeleted(postId: string) {
             {{ $t('dashboard.feedback.filtersBtn') }}
           </button>
         </DropdownMenuTrigger>
-        <DropdownMenuContent align="start" class="w-48">
-          <DropdownMenuItem
-            v-for="def in availableFields"
-            :key="def.key"
-            class="cursor-pointer"
-            @select="addCondition(def.key)"
-          >
-            <Icon :name="def.icon" size="14" class="mr-2" />
-            {{ def.label }}
-          </DropdownMenuItem>
-          <p v-if="!availableFields.length" class="px-2 py-3 text-center text-[11px] text-muted-foreground">
-            {{ $t('dashboard.filter.noFieldsLeft') }}
-          </p>
+        <DropdownMenuContent align="start" :class="picking ? 'min-w-[220px] max-w-[320px]' : 'w-48'">
+          <template v-if="picking">
+            <button
+              class="w-full flex items-center gap-1.5 px-2 py-1.5 text-[10px] font-bold uppercase tracking-wider text-muted-foreground hover:text-foreground transition-colors border-b border-border"
+              @click="pickingField = null"
+            >
+              <Icon name="lucide:chevron-left" size="12" class="shrink-0" />
+              {{ picking.def.label }}
+            </button>
+            <FilterValuePanel
+              :kind="picking.def.kind"
+              :op="'op' in picking.condition ? picking.condition.op : 'is'"
+              :values="'values' in picking.condition ? picking.condition.values : 'value' in picking.condition ? [picking.condition.value] : []"
+              :from="'from' in picking.condition ? picking.condition.from : undefined"
+              :to="'to' in picking.condition ? picking.condition.to : undefined"
+              :options="picking.def.options"
+              :searchable="'searchable' in picking.def && picking.def.searchable"
+              @update:op="patchCondition(picking.def.key, { op: $event })"
+              @update:values="patchCondition(picking.def.key, picking.def.kind === 'single' ? { value: $event[0] } : { values: $event })"
+              @update:range="patchCondition(picking.def.key, $event)"
+            />
+          </template>
+          <template v-else>
+            <DropdownMenuItem
+              v-for="def in availableFields"
+              :key="def.key"
+              class="cursor-pointer"
+              @select.prevent="startPicking(def.key)"
+            >
+              <Icon :name="def.icon" size="14" class="mr-2" />
+              {{ def.label }}
+            </DropdownMenuItem>
+            <p v-if="!availableFields.length" class="px-2 py-3 text-center text-[11px] text-muted-foreground">
+              {{ $t('dashboard.filter.noFieldsLeft') }}
+            </p>
+          </template>
         </DropdownMenuContent>
       </DropdownMenu>
 

--- a/app/pages/dashboard/feedback.vue
+++ b/app/pages/dashboard/feedback.vue
@@ -258,35 +258,33 @@ function onPostDeleted(postId: string) {
     />
     <div class="flex-1 flex flex-col overflow-hidden bg-card min-w-0">
       <!-- Filter bar -->
-      <div v-if="activeChips.length > 0" class="px-6 py-4 border-b border-border flex items-center justify-between bg-background/30">
-        <div class="flex items-center gap-2 min-w-0">
-          <span class="text-[11px] font-bold text-muted-foreground uppercase tracking-wider mr-2 shrink-0">{{ $t('dashboard.feedback.activeFilters') }}</span>
-          <div class="flex items-center gap-2 overflow-x-auto">
-            <FilterChip
-              v-for="{ condition, def } in activeChips"
-              :key="def.key"
-              :label="def.label"
-              :icon="def.icon"
-              :kind="def.kind"
-              :op="'op' in condition ? condition.op : 'is'"
-              :values="'values' in condition ? condition.values : 'value' in condition ? [condition.value] : []"
-              :from="'from' in condition ? condition.from : undefined"
-              :to="'to' in condition ? condition.to : undefined"
-              :options="def.options"
-              :searchable="'searchable' in def && def.searchable"
-              @update:op="patchCondition(def.key, { op: $event })"
-              @update:values="patchCondition(def.key, def.kind === 'single' ? { value: $event[0] } : { values: $event })"
-              @update:range="patchCondition(def.key, $event)"
-              @remove="removeCondition(def.key)"
-            />
-          </div>
-          <button
-            class="text-[10px] font-bold text-muted-foreground hover:text-primary transition-colors ml-2 underline underline-offset-2 shrink-0"
-            @click="clearAllFilters"
-          >
-            {{ $t('dashboard.feedback.clearAll') }}
-          </button>
+      <div v-if="activeChips.length > 0" class="px-6 py-4 border-b border-border flex items-end justify-between gap-3 bg-background/30">
+        <div class="flex flex-wrap items-center gap-2 min-w-0">
+          <span class="hidden sm:inline text-[11px] font-bold text-muted-foreground uppercase tracking-wider mr-2 shrink-0">{{ $t('dashboard.feedback.activeFilters') }}</span>
+          <FilterChip
+            v-for="{ condition, def } in activeChips"
+            :key="def.key"
+            :label="def.label"
+            :icon="def.icon"
+            :kind="def.kind"
+            :op="'op' in condition ? condition.op : 'is'"
+            :values="'values' in condition ? condition.values : 'value' in condition ? [condition.value] : []"
+            :from="'from' in condition ? condition.from : undefined"
+            :to="'to' in condition ? condition.to : undefined"
+            :options="def.options"
+            :searchable="'searchable' in def && def.searchable"
+            @update:op="patchCondition(def.key, { op: $event })"
+            @update:values="patchCondition(def.key, def.kind === 'single' ? { value: $event[0] } : { values: $event })"
+            @update:range="patchCondition(def.key, $event)"
+            @remove="removeCondition(def.key)"
+          />
         </div>
+        <button
+          class="relative inline-flex items-center h-7 shrink-0 text-[10px] font-bold text-muted-foreground hover:text-primary transition-colors underline underline-offset-2 after:absolute after:content-[''] after:-inset-x-3 after:-inset-y-2 sm:after:content-none"
+          @click="clearAllFilters"
+        >
+          {{ $t('dashboard.feedback.clearAll') }}
+        </button>
       </div>
 
       <!-- Data table -->

--- a/app/pages/dashboard/feedback.vue
+++ b/app/pages/dashboard/feedback.vue
@@ -10,131 +10,106 @@ const { t } = useI18n()
 
 // ---- Filter system ----
 
-interface FilterType {
-  key: string
-  label: string
-  icon: string
-  options: { value: string; label: string }[]
+type FieldKey = 'status' | 'boardId' | 'author' | 'created' | 'merged'
+
+const { data: authorsData } = await useFetch<{ data: { id: string, name: string | null, email: string | null, image: string | null }[] }>('/api/admin/posts/authors')
+const authors = computed(() => authorsData.value?.data ?? [])
+
+const fieldDefs = computed(() => [
+  {
+    key: 'status' as FieldKey, kind: 'enum' as const, label: t('dashboard.filter.status'), icon: 'lucide:activity',
+    options: STATUS_OPTIONS.map(o => ({ value: o.value, label: t(statusLabelKey(o.value)), color: o.color })),
+  },
+  {
+    key: 'boardId' as FieldKey, kind: 'enum' as const, label: t('dashboard.filter.board'), icon: 'lucide:layers',
+    options: [
+      ...boards.value.map(b => ({ value: b.id, label: b.name })),
+      { value: 'none', label: t('dashboard.filter.noBoard') },
+    ],
+  },
+  {
+    key: 'author' as FieldKey, kind: 'enum' as const, label: t('dashboard.filter.author'), icon: 'lucide:user', searchable: true,
+    options: authors.value.map(a => ({ value: a.id, label: a.name || a.email || a.id, sub: a.email || '', image: a.image })),
+  },
+  { key: 'created' as FieldKey, kind: 'date' as const, label: t('dashboard.filter.created'), icon: 'lucide:calendar', options: [] },
+  {
+    key: 'merged' as FieldKey, kind: 'single' as const, label: t('dashboard.filter.merged'), icon: 'lucide:git-merge',
+    options: [
+      { value: 'canonical_only', label: t('dashboard.feedback.canonicalOnly') },
+      { value: 'merged_only', label: t('dashboard.feedback.mergedOnly') },
+      { value: 'all', label: t('dashboard.all') },
+    ],
+  },
+])
+
+const route = useRoute()
+const conditions = ref<FilterCondition[]>(parseFilterQuery(route.query as Record<string, unknown>))
+
+const activeChips = computed(() =>
+  conditions.value
+    .map(c => ({ condition: c, def: fieldDefs.value.find(d => d.key === c.field)! }))
+    .filter(x => x.def))
+
+const availableFields = computed(() => {
+  const used = new Set(conditions.value.map(c => c.field))
+  return fieldDefs.value.filter(d => !used.has(d.key))
+})
+
+function addCondition(key: FieldKey) {
+  const created: FilterCondition = key === 'created'
+    ? { field: 'created', op: 'after' }
+    : key === 'merged'
+      ? { field: 'merged', value: 'canonical_only' }
+      : { field: key as EnumFilterField, op: 'is', values: [] }
+  conditions.value = [...conditions.value, created]
 }
 
-
-const statusOptions = computed(() => [
-  { value: 'all', label: t('dashboard.all') },
-  ...STATUS_OPTIONS.map(s => ({ value: s.value, label: t(statusLabelKey(s.value)) })),
-])
-
-const boardOptions = computed(() => [
-  { value: 'all', label: t('dashboard.all') },
-  ...boards.value.map(b => ({ value: b.id, label: b.name })),
-])
-
-const mergedOptions = computed(() => [
-  { value: 'canonical_only', label: t('dashboard.feedback.canonicalOnly') },
-  { value: 'merged_only', label: t('dashboard.feedback.mergedOnly') },
-  { value: 'all', label: t('dashboard.all') },
-])
-
-const filterTypes = computed<FilterType[]>(() => [
-  { key: 'status', label: t('dashboard.filter.status'), icon: 'lucide:activity', options: statusOptions.value },
-  { key: 'boardId', label: t('dashboard.filter.board'), icon: 'lucide:layers', options: boardOptions.value },
-  { key: 'merged', label: t('dashboard.filter.merged'), icon: 'lucide:git-merge', options: mergedOptions.value },
-])
-
-// Active filters: Map<key, value>
-const filters = ref(new Map<string, string>())
-
-function addFilter(key: string, value: string) {
-  filters.value.set(key, value)
-  // Trigger reactivity
-  filters.value = new Map(filters.value)
+function patchCondition(field: string, patch: Record<string, unknown>) {
+  conditions.value = conditions.value.map(c => (c.field === field ? { ...c, ...patch } as FilterCondition : c))
 }
 
-function removeFilter(key: string) {
-  filters.value.delete(key)
-  filters.value = new Map(filters.value)
-}
-
-function updateFilterValue(key: string, value: string) {
-  filters.value.set(key, value)
-  filters.value = new Map(filters.value)
+function removeCondition(field: string) {
+  conditions.value = conditions.value.filter(c => c.field !== field)
 }
 
 function clearAllFilters() {
-  filters.value = new Map()
+  conditions.value = []
 }
 
-
-// Resolve display info for active filters
-const activeFilterEntries = computed(() => {
-  const entries: { key: string; label: string; icon: string; value: string; valueLabel: string; options: { value: string; label: string }[] }[] = []
-  for (const [key, value] of filters.value) {
-    const type = filterTypes.value.find(t => t.key === key)
-    if (!type) continue
-    const opt = type.options.find(o => o.value === value)
-    entries.push({
-      key,
-      label: type.label,
-      icon: type.icon,
-      value,
-      valueLabel: opt?.label ?? value,
-      options: type.options,
-    })
-  }
-  return entries
+const defaultBoardId = computed(() => {
+  const v = railValue(conditions.value, 'boardId')
+  return v && v !== 'none' ? v : undefined
 })
 
-// Build API query from filters (skip "all" values)
-const filterStatus = computed(() => {
-  const v = filters.value.get('status')
-  return v && v !== 'all' ? v : undefined
-})
-const filterBoardId = computed(() => {
-  const v = filters.value.get('boardId')
-  return v && v !== 'all' ? v : undefined
-})
-const filterMerged = computed(() => {
-  const v = filters.value.get('merged')
-  return v || 'canonical_only'
-})
+function pickRail(field: EnumFilterField, value: string) {
+  conditions.value = toggleRail(conditions.value, field, value)
+}
 
-// ---- Add filter dropdown state ----
 const addFilterOpen = ref(false)
-const addFilterStep = ref<'type' | 'value'>('type')
-const addFilterSelectedType = ref<FilterType | null>(null)
-
-function openAddFilter() {
-  addFilterStep.value = 'type'
-  addFilterSelectedType.value = null
-  addFilterOpen.value = true
-}
-
-function selectFilterType(type: FilterType) {
-  addFilterSelectedType.value = type
-  addFilterStep.value = 'value'
-}
-
-function selectFilterValue(value: string) {
-  if (addFilterSelectedType.value) {
-    addFilter(addFilterSelectedType.value.key, value)
-  }
-  addFilterOpen.value = false
-}
 
 // ---- Sort & Pagination ----
-const sortBy = ref<'createdAt' | 'votes' | 'comments'>('createdAt')
-const currentPage = ref(1)
+const sortBy = ref<'createdAt' | 'votes' | 'comments'>(
+  (['createdAt', 'votes', 'comments'].includes(route.query.sort as string) ? route.query.sort : 'createdAt') as 'createdAt' | 'votes' | 'comments')
+const currentPage = ref(Math.max(Number(route.query.page) || 1, 1))
 const pageSize = 10
 
-// Reset page when filters change
-watch(filters, () => {
+const searchTerm = ref((route.query.q as string) || '')
+const searchActive = computed(() => searchTerm.value.length > 0)
+
+watch([conditions, searchTerm], () => {
   currentPage.value = 1
 }, { deep: true })
 
-const searchTerm = ref('')
-const searchActive = computed(() => searchTerm.value.length > 0)
-watch(searchTerm, () => {
-  currentPage.value = 1
-})
+// replaceState, not the router — a push would re-run the route watchers and
+// refetch a list we already have.
+watch([conditions, searchTerm, sortBy, currentPage], () => {
+  const qs = serializeFilterQuery(conditions.value, {
+    q: searchTerm.value,
+    sort: sortBy.value,
+    page: currentPage.value,
+  })
+  window.history.replaceState(window.history.state, '', qs ? `${route.path}?${qs}` : route.path)
+}, { deep: true })
 
 // While searching, route to the additive /search endpoint; otherwise use the
 // standard list endpoint. Both return PagePaginatedList<PostListItem>.
@@ -142,11 +117,8 @@ const apiUrl = computed(() => searchActive.value ? '/api/admin/posts/search' : '
 
 // Fetch data
 const { data: postsData, refresh: refreshPosts, status: fetchStatus } = await useFetch<PagePaginatedList<PostListItem>>(apiUrl, {
-  query: computed(() => ({
+  query: computed(() => filterApiQuery(conditions.value, {
     q: searchTerm.value || undefined,
-    status: filterStatus.value,
-    boardId: filterBoardId.value,
-    merged: filterMerged.value,
     sort: sortBy.value,
     page: currentPage.value,
     pageSize,
@@ -200,13 +172,13 @@ function onPostUpdated(updated: { id: string; status?: string; boardId?: string 
   const idx = list.findIndex(p => p.id === updated.id)
   if (idx === -1) return
 
-  // If status/board changed and no longer matches active filters, remove
-  if (updated.status !== undefined && filterStatus.value && updated.status !== filterStatus.value) {
-    list.splice(idx, 1)
-    if (postsData.value?.pagination) postsData.value.pagination.total--
-    return
+  const dropped = (field: EnumFilterField, value: string) => {
+    const c = findCondition(conditions.value, field)
+    if (!c || c.field === 'created' || c.field === 'merged' || !c.values.length) return false
+    return c.op === 'is' ? !c.values.includes(value) : c.values.includes(value)
   }
-  if (updated.boardId !== undefined && filterBoardId.value && updated.boardId !== filterBoardId.value) {
+  if ((updated.status !== undefined && dropped('status', updated.status))
+    || (updated.boardId !== undefined && dropped('boardId', updated.boardId ?? 'none'))) {
     list.splice(idx, 1)
     if (postsData.value?.pagination) postsData.value.pagination.total--
     return
@@ -243,36 +215,24 @@ function onPostDeleted(postId: string) {
         <DropdownMenuTrigger as-child>
           <button
             class="h-9 px-3 rounded-lg border border-border bg-background text-xs font-heading font-bold text-muted-foreground hover:text-foreground hover:border-primary transition-all flex items-center gap-2"
-            @click="openAddFilter"
           >
             <Icon name="lucide:filter" size="16" />
             {{ $t('dashboard.feedback.filtersBtn') }}
           </button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="start" class="w-48">
-          <!-- Step 1: Choose filter type -->
-          <template v-if="addFilterStep === 'type'">
-            <DropdownMenuItem
-              v-for="type in filterTypes"
-              :key="type.key"
-              class="cursor-pointer"
-              @select.prevent="selectFilterType(type)"
-            >
-              <Icon :name="type.icon" size="14" class="mr-2" />
-              {{ type.label }}
-            </DropdownMenuItem>
-          </template>
-          <!-- Step 2: Choose value -->
-          <template v-else-if="addFilterStep === 'value' && addFilterSelectedType">
-            <DropdownMenuItem
-              v-for="opt in addFilterSelectedType.options.filter(o => o.value !== 'all')"
-              :key="opt.value"
-              class="cursor-pointer"
-              @select="selectFilterValue(opt.value)"
-            >
-              {{ opt.label }}
-            </DropdownMenuItem>
-          </template>
+          <DropdownMenuItem
+            v-for="def in availableFields"
+            :key="def.key"
+            class="cursor-pointer"
+            @select="addCondition(def.key)"
+          >
+            <Icon :name="def.icon" size="14" class="mr-2" />
+            {{ def.label }}
+          </DropdownMenuItem>
+          <p v-if="!availableFields.length" class="px-2 py-3 text-center text-[11px] text-muted-foreground">
+            {{ $t('dashboard.filter.noFieldsLeft') }}
+          </p>
         </DropdownMenuContent>
       </DropdownMenu>
 
@@ -288,26 +248,39 @@ function onPostDeleted(postId: string) {
   </header>
 
   <!-- Main content -->
-  <div class="flex-1 flex flex-col min-h-0">
-    <div class="flex-1 flex flex-col overflow-hidden bg-card">
+  <div class="flex-1 flex min-h-0">
+    <FeedbackQuickFilters
+      :conditions="conditions"
+      :boards="boards"
+      @pick="pickRail"
+      @clear="clearAllFilters"
+    />
+    <div class="flex-1 flex flex-col overflow-hidden bg-card min-w-0">
       <!-- Filter bar -->
-      <div v-if="activeFilterEntries.length > 0" class="px-6 py-4 border-b border-border flex items-center justify-between bg-background/30">
-        <div class="flex flex-wrap items-center gap-2">
-          <span class="text-[11px] font-bold text-muted-foreground uppercase tracking-wider mr-2">{{ $t('dashboard.feedback.activeFilters') }}</span>
-          <div class="flex items-center gap-2">
-            <FilterTag
-              v-for="entry in activeFilterEntries"
-              :key="entry.key"
-              :label="entry.label"
-              :icon="entry.icon"
-              :model-value="entry.value"
-              :options="entry.options"
-              @update:model-value="updateFilterValue(entry.key, $event)"
-              @remove="removeFilter(entry.key)"
+      <div v-if="activeChips.length > 0" class="px-6 py-4 border-b border-border flex items-center justify-between bg-background/30">
+        <div class="flex items-center gap-2 min-w-0">
+          <span class="text-[11px] font-bold text-muted-foreground uppercase tracking-wider mr-2 shrink-0">{{ $t('dashboard.feedback.activeFilters') }}</span>
+          <div class="flex items-center gap-2 overflow-x-auto">
+            <FilterChip
+              v-for="{ condition, def } in activeChips"
+              :key="def.key"
+              :label="def.label"
+              :icon="def.icon"
+              :kind="def.kind"
+              :op="'op' in condition ? condition.op : 'is'"
+              :values="'values' in condition ? condition.values : 'value' in condition ? [condition.value] : []"
+              :from="'from' in condition ? condition.from : undefined"
+              :to="'to' in condition ? condition.to : undefined"
+              :options="def.options"
+              :searchable="'searchable' in def && def.searchable"
+              @update:op="patchCondition(def.key, { op: $event })"
+              @update:values="patchCondition(def.key, def.kind === 'single' ? { value: $event[0] } : { values: $event })"
+              @update:range="patchCondition(def.key, $event)"
+              @remove="removeCondition(def.key)"
             />
           </div>
           <button
-            class="text-[10px] font-bold text-muted-foreground hover:text-primary transition-colors ml-2 underline underline-offset-2"
+            class="text-[10px] font-bold text-muted-foreground hover:text-primary transition-colors ml-2 underline underline-offset-2 shrink-0"
             @click="clearAllFilters"
           >
             {{ $t('dashboard.feedback.clearAll') }}
@@ -331,6 +304,13 @@ function onPostDeleted(postId: string) {
           <p class="text-sm mt-1">
             {{ searchActive ? $t('dashboard.feedback.searchNoMatchHint') : $t('dashboard.feedback.noResultsHint') }}
           </p>
+          <button
+            v-if="conditions.length"
+            class="mt-4 h-8 px-3 rounded-lg border border-border text-xs font-bold hover:text-primary hover:border-primary transition-colors"
+            @click="clearAllFilters"
+          >
+            {{ $t('dashboard.feedback.clearAllFilters') }}
+          </button>
         </div>
 
         <template v-else>
@@ -409,10 +389,10 @@ function onPostDeleted(postId: string) {
                   </div>
                 </th>
                 <th class="w-1/4 px-4 py-3 text-[11px] font-bold uppercase tracking-wider text-muted-foreground">{{ $t('dashboard.feedback.colTitle') }}</th>
-                <th class="w-32 px-4 py-3 text-[11px] font-bold uppercase tracking-wider text-muted-foreground">{{ $t('dashboard.feedback.colBoard') }}</th>
-                <th class="w-40 px-4 py-3 text-[11px] font-bold uppercase tracking-wider text-muted-foreground">{{ $t('dashboard.feedback.colAuthor') }}</th>
+                <th class="w-48 px-4 py-3 text-[11px] font-bold uppercase tracking-wider text-muted-foreground">{{ $t('dashboard.feedback.colBoard') }}</th>
+                <th class="w-36 px-4 py-3 text-[11px] font-bold uppercase tracking-wider text-muted-foreground">{{ $t('dashboard.feedback.colAuthor') }}</th>
                 <th
-                  class="w-32 px-4 py-3 text-[11px] font-bold uppercase tracking-wider text-muted-foreground cursor-pointer hover:text-primary transition-colors"
+                  class="w-24 px-4 py-3 text-[11px] font-bold uppercase tracking-wider text-muted-foreground cursor-pointer hover:text-primary transition-colors"
                   @click="toggleSort('comments')"
                 >
                   <div class="flex items-center gap-1">
@@ -429,7 +409,7 @@ function onPostDeleted(postId: string) {
                     <Icon v-if="sortBy === 'createdAt'" name="lucide:arrow-down" size="14" class="text-primary" />
                   </div>
                 </th>
-                <th class="w-32 px-4 py-3 text-[11px] font-bold uppercase tracking-wider text-muted-foreground">{{ $t('dashboard.feedback.colStatus') }}</th>
+                <th class="w-28 px-4 py-3 text-[11px] font-bold uppercase tracking-wider text-muted-foreground">{{ $t('dashboard.feedback.colStatus') }}</th>
               </tr>
             </thead>
             <tbody class="divide-y divide-border">
@@ -455,7 +435,11 @@ function onPostDeleted(postId: string) {
                 </td>
                 <!-- Board -->
                 <td class="px-4 py-4">
-                  <span v-if="fb.boardId" class="text-xs font-medium text-muted-foreground bg-muted px-2 py-1 rounded">
+                  <span
+                    v-if="fb.boardId"
+                    class="inline-block max-w-full truncate text-xs font-medium text-muted-foreground bg-muted px-2 py-1 rounded whitespace-nowrap"
+                    :title="boardMap.get(fb.boardId) ?? $t('dashboard.feedback.unknownBoard')"
+                  >
                     {{ boardMap.get(fb.boardId) ?? $t('dashboard.feedback.unknownBoard') }}
                   </span>
                   <span v-else class="text-xs italic text-muted-foreground">—</span>
@@ -549,7 +533,7 @@ function onPostDeleted(postId: string) {
   </div>
 
   <!-- Modals -->
-  <SubmitModal v-model:open="showSubmit" :default-board-id="filterBoardId" @created="refreshPosts()" />
+  <SubmitModal v-model:open="showSubmit" :default-board-id="defaultBoardId" @created="refreshPosts()" />
   <PostDetailModal v-model:open="showDetail" :slug="detailSlug" @updated="onPostUpdated" @deleted="onPostDeleted" />
 </template>
 

--- a/app/pages/dashboard/feedback.vue
+++ b/app/pages/dashboard/feedback.vue
@@ -122,6 +122,7 @@ const addFilterOpen = ref(false)
 // ---- Sort & Pagination ----
 const sortBy = ref<'createdAt' | 'votes' | 'comments'>(
   (['createdAt', 'votes', 'comments'].includes(route.query.sort as string) ? route.query.sort : 'createdAt') as 'createdAt' | 'votes' | 'comments')
+const sortOrder = ref<'asc' | 'desc'>(route.query.order === 'asc' ? 'asc' : 'desc')
 const currentPage = ref(Math.max(Number(route.query.page) || 1, 1))
 const pageSize = 10
 
@@ -134,10 +135,11 @@ watch([conditions, searchTerm], () => {
 
 // replaceState, not the router — a push would re-run the route watchers and
 // refetch a list we already have.
-watch([conditions, searchTerm, sortBy, currentPage], () => {
+watch([conditions, searchTerm, sortBy, sortOrder, currentPage], () => {
   const qs = serializeFilterQuery(conditions.value, {
     q: searchTerm.value,
     sort: sortBy.value,
+    order: sortOrder.value,
     page: currentPage.value,
   })
   window.history.replaceState(window.history.state, '', qs ? `${route.path}?${qs}` : route.path)
@@ -152,6 +154,7 @@ const { data: postsData, refresh: refreshPosts, status: fetchStatus } = await us
   query: computed(() => filterApiQuery(conditions.value, {
     q: searchTerm.value || undefined,
     sort: sortBy.value,
+    order: sortOrder.value,
     page: currentPage.value,
     pageSize,
   })),
@@ -165,6 +168,7 @@ const totalPages = computed(() => Math.ceil(pagination.value.total / pagination.
 
 // Sort handler
 function toggleSort(col: 'createdAt' | 'votes' | 'comments') {
+  sortOrder.value = sortBy.value === col && sortOrder.value === 'desc' ? 'asc' : 'desc'
   sortBy.value = col
   currentPage.value = 1
 }
@@ -439,7 +443,7 @@ function onPostDeleted(postId: string) {
                 >
                   <div class="flex items-center gap-1">
                     {{ $t('dashboard.feedback.colUpvotes') }}
-                    <Icon v-if="sortBy === 'votes'" name="lucide:arrow-down" size="14" class="text-primary" />
+                    <Icon v-if="sortBy === 'votes'" :name="sortOrder === 'asc' ? 'lucide:arrow-up' : 'lucide:arrow-down'" size="14" class="text-primary" />
                   </div>
                 </th>
                 <th class="w-1/4 px-4 py-3 text-[11px] font-bold uppercase tracking-wider text-muted-foreground">{{ $t('dashboard.feedback.colTitle') }}</th>
@@ -451,7 +455,7 @@ function onPostDeleted(postId: string) {
                 >
                   <div class="flex items-center gap-1">
                     {{ $t('dashboard.feedback.colComments') }}
-                    <Icon v-if="sortBy === 'comments'" name="lucide:arrow-down" size="14" class="text-primary" />
+                    <Icon v-if="sortBy === 'comments'" :name="sortOrder === 'asc' ? 'lucide:arrow-up' : 'lucide:arrow-down'" size="14" class="text-primary" />
                   </div>
                 </th>
                 <th
@@ -460,7 +464,7 @@ function onPostDeleted(postId: string) {
                 >
                   <div class="flex items-center gap-1">
                     {{ $t('dashboard.feedback.colCreated') }}
-                    <Icon v-if="sortBy === 'createdAt'" name="lucide:arrow-down" size="14" class="text-primary" />
+                    <Icon v-if="sortBy === 'createdAt'" :name="sortOrder === 'asc' ? 'lucide:arrow-up' : 'lucide:arrow-down'" size="14" class="text-primary" />
                   </div>
                 </th>
                 <th class="w-[80px] px-4 py-3 text-[11px] font-bold uppercase tracking-wider text-muted-foreground">{{ $t('dashboard.feedback.colStatus') }}</th>

--- a/app/pages/dashboard/feedback.vue
+++ b/app/pages/dashboard/feedback.vue
@@ -55,27 +55,45 @@ const availableFields = computed(() => {
   return fieldDefs.value.filter(d => !used.has(d.key))
 })
 
-function addCondition(key: FieldKey) {
-  const created: FilterCondition = key === 'created'
+function blankCondition(key: FieldKey): FilterCondition {
+  return key === 'created'
     ? { field: 'created', op: 'after' }
     : key === 'merged'
-      ? { field: 'merged', value: 'canonical_only' }
+      ? { field: 'merged', value: '' }
       : { field: key as EnumFilterField, op: 'is', values: [] }
-  conditions.value = [...conditions.value, created]
+}
+
+function hasValue(c: FilterCondition) {
+  if (c.field === 'created') return Boolean(c.from || c.to)
+  if (c.field === 'merged') return Boolean(c.value)
+  return c.values.length > 0
 }
 
 const pickingField = ref<FieldKey | null>(null)
+const draft = ref<FilterCondition | null>(null)
 
 const picking = computed(() => {
-  if (!pickingField.value) return null
   const def = fieldDefs.value.find(d => d.key === pickingField.value)
-  const condition = conditions.value.find(c => c.field === pickingField.value)
-  return def && condition ? { def, condition } : null
+  return def && draft.value ? { def, condition: draft.value } : null
 })
 
 function startPicking(key: FieldKey) {
-  addCondition(key)
   pickingField.value = key
+  draft.value = blankCondition(key)
+}
+
+function resetPicking() {
+  pickingField.value = null
+  draft.value = null
+}
+
+// Also removes: unchecking the last value must drop the condition, not leave an empty chip.
+function patchDraft(patch: Record<string, unknown>) {
+  if (!draft.value) return
+  const next = { ...draft.value, ...patch } as FilterCondition
+  draft.value = next
+  const rest = conditions.value.filter(c => c.field !== next.field)
+  conditions.value = hasValue(next) ? [...rest, next] : rest
 }
 
 function patchCondition(field: string, patch: Record<string, unknown>) {
@@ -225,7 +243,7 @@ function onPostDeleted(postId: string) {
       <AdminFeedbackSearch v-model="searchTerm" />
 
       <!-- Filters button -->
-      <DropdownMenu v-model:open="addFilterOpen" @update:open="pickingField = null">
+      <DropdownMenu v-model:open="addFilterOpen" @update:open="resetPicking">
         <DropdownMenuTrigger as-child>
           <button
             class="h-9 px-3 rounded-lg border border-border bg-background text-xs font-heading font-bold text-muted-foreground hover:text-foreground hover:border-primary transition-all flex items-center gap-2"
@@ -238,7 +256,7 @@ function onPostDeleted(postId: string) {
           <template v-if="picking">
             <button
               class="w-full flex items-center gap-1.5 px-2 py-1.5 text-[10px] font-bold uppercase tracking-wider text-muted-foreground hover:text-foreground transition-colors border-b border-border"
-              @click="pickingField = null"
+              @click="resetPicking"
             >
               <Icon name="lucide:chevron-left" size="12" class="shrink-0" />
               {{ picking.def.label }}
@@ -251,9 +269,9 @@ function onPostDeleted(postId: string) {
               :to="'to' in picking.condition ? picking.condition.to : undefined"
               :options="picking.def.options"
               :searchable="'searchable' in picking.def && picking.def.searchable"
-              @update:op="patchCondition(picking.def.key, { op: $event })"
-              @update:values="patchCondition(picking.def.key, picking.def.kind === 'single' ? { value: $event[0] } : { values: $event })"
-              @update:range="patchCondition(picking.def.key, $event)"
+              @update:op="patchDraft({ op: $event })"
+              @update:values="patchDraft(picking.def.kind === 'single' ? { value: $event[0] } : { values: $event })"
+              @update:range="patchDraft($event)"
             />
           </template>
           <template v-else>

--- a/app/pages/dashboard/feedback.vue
+++ b/app/pages/dashboard/feedback.vue
@@ -430,11 +430,11 @@ function onPostDeleted(postId: string) {
           </div>
 
           <!-- Desktop table -->
-          <table class="hidden md:table w-full text-left border-collapse min-w-[1000px] table-fixed">
+          <table class="hidden md:table w-full text-left border-collapse min-w-[900px] table-fixed">
             <thead class="sticky top-0 bg-background border-b border-border z-10">
               <tr>
                 <th
-                  class="w-24 px-6 py-3 text-[11px] font-bold uppercase tracking-wider text-muted-foreground cursor-pointer hover:text-primary transition-colors"
+                  class="w-[72px] px-4 py-3 text-[11px] font-bold uppercase tracking-wider text-muted-foreground cursor-pointer hover:text-primary transition-colors"
                   @click="toggleSort('votes')"
                 >
                   <div class="flex items-center gap-1">
@@ -443,10 +443,10 @@ function onPostDeleted(postId: string) {
                   </div>
                 </th>
                 <th class="w-1/4 px-4 py-3 text-[11px] font-bold uppercase tracking-wider text-muted-foreground">{{ $t('dashboard.feedback.colTitle') }}</th>
-                <th class="w-48 px-4 py-3 text-[11px] font-bold uppercase tracking-wider text-muted-foreground">{{ $t('dashboard.feedback.colBoard') }}</th>
-                <th class="w-36 px-4 py-3 text-[11px] font-bold uppercase tracking-wider text-muted-foreground">{{ $t('dashboard.feedback.colAuthor') }}</th>
+                <th class="w-[152px] px-4 py-3 text-[11px] font-bold uppercase tracking-wider text-muted-foreground">{{ $t('dashboard.feedback.colBoard') }}</th>
+                <th class="w-[160px] px-4 py-3 text-[11px] font-bold uppercase tracking-wider text-muted-foreground">{{ $t('dashboard.feedback.colAuthor') }}</th>
                 <th
-                  class="w-24 px-4 py-3 text-[11px] font-bold uppercase tracking-wider text-muted-foreground cursor-pointer hover:text-primary transition-colors"
+                  class="w-[104px] px-4 py-3 text-[11px] font-bold uppercase tracking-wider text-muted-foreground cursor-pointer hover:text-primary transition-colors"
                   @click="toggleSort('comments')"
                 >
                   <div class="flex items-center gap-1">
@@ -455,7 +455,7 @@ function onPostDeleted(postId: string) {
                   </div>
                 </th>
                 <th
-                  class="w-32 px-4 py-3 text-[11px] font-bold uppercase tracking-wider text-muted-foreground cursor-pointer hover:text-primary transition-colors"
+                  class="w-[122px] px-4 py-3 text-[11px] font-bold uppercase tracking-wider text-muted-foreground cursor-pointer hover:text-primary transition-colors"
                   @click="toggleSort('createdAt')"
                 >
                   <div class="flex items-center gap-1">
@@ -463,7 +463,7 @@ function onPostDeleted(postId: string) {
                     <Icon v-if="sortBy === 'createdAt'" name="lucide:arrow-down" size="14" class="text-primary" />
                   </div>
                 </th>
-                <th class="w-28 px-4 py-3 text-[11px] font-bold uppercase tracking-wider text-muted-foreground">{{ $t('dashboard.feedback.colStatus') }}</th>
+                <th class="w-[80px] px-4 py-3 text-[11px] font-bold uppercase tracking-wider text-muted-foreground">{{ $t('dashboard.feedback.colStatus') }}</th>
               </tr>
             </thead>
             <tbody class="divide-y divide-border">

--- a/app/pages/dashboard/feedback.vue
+++ b/app/pages/dashboard/feedback.vue
@@ -202,7 +202,7 @@ function onPostDeleted(postId: string) {
   <!-- Top bar -->
   <header class="h-14 md:h-16 px-4 md:px-6 border-b border-border flex items-center justify-between shrink-0 bg-card backdrop-blur-sm">
     <div class="flex items-center gap-4">
-      <h2 class="font-heading text-lg font-bold">{{ $t('dashboard.feedback.title') }}</h2>
+      <h2 class="hidden sm:block font-heading text-lg font-bold">{{ $t('dashboard.feedback.title') }}</h2>
       <div class="hidden md:block h-4 w-[1px] bg-border" />
       <span class="hidden md:block text-xs font-medium text-muted-foreground">{{ $t('dashboard.feedback.subtitle') }}</span>
     </div>
@@ -238,11 +238,12 @@ function onPostDeleted(postId: string) {
 
       <!-- Create button -->
       <button
-        class="h-9 px-4 rounded-lg bg-primary text-primary-foreground text-xs font-heading font-bold hover:opacity-90 transition-all flex items-center gap-2"
+        class="h-9 px-3 sm:px-4 rounded-lg bg-primary text-primary-foreground text-xs font-heading font-bold hover:opacity-90 transition-all flex items-center gap-2 shrink-0"
+        :aria-label="$t('dashboard.feedback.create')"
         @click="showSubmit = true"
       >
         <Icon name="lucide:plus" size="16" />
-        {{ $t('dashboard.feedback.create') }}
+        <span class="hidden sm:inline">{{ $t('dashboard.feedback.create') }}</span>
       </button>
     </div>
   </header>

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -434,6 +434,7 @@
       "author": "Author",
       "created": "Created",
       "noBoard": "No board",
+      "staleValue": "Unavailable",
       "noFieldsLeft": "No filters left",
       "noMatches": "No matches",
       "pickDate": "Pick a date",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -430,7 +430,25 @@
     "filter": {
       "status": "Status",
       "board": "Board",
-      "merged": "Merged"
+      "merged": "Merged",
+      "author": "Author",
+      "created": "Created",
+      "noBoard": "No board",
+      "noFieldsLeft": "No filters left",
+      "noMatches": "No matches",
+      "pickDate": "Pick a date",
+      "pickValue": "Pick a value",
+      "searchPlaceholder": "Search",
+      "last7": "Last 7 days",
+      "last30": "Last 30 days",
+      "thisQuarter": "This quarter",
+      "op": {
+        "is": "Is",
+        "not": "Is not",
+        "before": "Before",
+        "after": "After",
+        "range": "Between"
+      }
     },
     "nav": {
       "srTitle": "Navigation",
@@ -487,7 +505,10 @@
       "entriesShort": "{total} entries",
       "searchPlaceholder": "Search feedback…",
       "searchAria": "Search feedback",
-      "clearSearch": "Clear search"
+      "clearSearch": "Clear search",
+      "clearAllFilters": "Clear all filters",
+      "quickFilters": "Quick filters",
+      "statuses": "Statuses"
     },
     "sso": {
       "title": "Single Sign-On",

--- a/i18n/locales/zh.json
+++ b/i18n/locales/zh.json
@@ -433,7 +433,7 @@
       "merged": "合并",
       "author": "提交人",
       "created": "创建时间",
-      "noBoard": "无板块",
+      "noBoard": "无看板",
       "staleValue": "已失效",
       "noFieldsLeft": "没有可用字段",
       "noMatches": "无匹配项",

--- a/i18n/locales/zh.json
+++ b/i18n/locales/zh.json
@@ -434,6 +434,7 @@
       "author": "提交人",
       "created": "创建时间",
       "noBoard": "无板块",
+      "staleValue": "已失效",
       "noFieldsLeft": "没有可用字段",
       "noMatches": "无匹配项",
       "pickDate": "选择日期",

--- a/i18n/locales/zh.json
+++ b/i18n/locales/zh.json
@@ -430,7 +430,25 @@
     "filter": {
       "status": "状态",
       "board": "看板",
-      "merged": "合并"
+      "merged": "合并",
+      "author": "提交人",
+      "created": "创建时间",
+      "noBoard": "无板块",
+      "noFieldsLeft": "没有可用字段",
+      "noMatches": "无匹配项",
+      "pickDate": "选择日期",
+      "pickValue": "选择值",
+      "searchPlaceholder": "搜索",
+      "last7": "近 7 天",
+      "last30": "近 30 天",
+      "thisQuarter": "本季度",
+      "op": {
+        "is": "是",
+        "not": "不是",
+        "before": "早于",
+        "after": "晚于",
+        "range": "区间"
+      }
     },
     "nav": {
       "srTitle": "导航",
@@ -487,7 +505,10 @@
       "entriesShort": "共 {total} 条",
       "searchPlaceholder": "搜索反馈…",
       "searchAria": "搜索反馈",
-      "clearSearch": "清除搜索"
+      "clearSearch": "清除搜索",
+      "clearAllFilters": "清空全部筛选",
+      "quickFilters": "快捷筛选",
+      "statuses": "状态"
     },
     "sso": {
       "title": "单点登录",

--- a/server/api/admin/posts/authors.get.ts
+++ b/server/api/admin/posts/authors.get.ts
@@ -1,0 +1,27 @@
+import { eq, desc, sql } from 'drizzle-orm'
+import { post, user } from '#layers/feedlog/server/db/schemas'
+
+// GET /api/admin/posts/authors — candidate values for the Author filter.
+// Not narrowed by the active filters, and merged posts count toward the total.
+export default defineEventHandler(async (event) => {
+  const { orgId } = await requireOrgMember(event)
+
+  const db = useDB()
+  const total = sql<number>`cast(count(*) as int)`
+
+  const rows = await db
+    .select({
+      id: post.authorId,
+      name: user.name,
+      email: user.email,
+      image: user.image,
+      count: total,
+    })
+    .from(post)
+    .leftJoin(user, eq(post.authorId, user.id))
+    .where(eq(post.orgId, orgId))
+    .groupBy(post.authorId, user.name, user.email, user.image)
+    .orderBy(desc(total), desc(post.authorId))
+
+  return { data: rows }
+})

--- a/server/api/admin/posts/index.get.ts
+++ b/server/api/admin/posts/index.get.ts
@@ -1,4 +1,4 @@
-import { eq, and, desc, sql } from 'drizzle-orm'
+import { eq, and, asc, desc, sql } from 'drizzle-orm'
 import { post, user } from '#layers/feedlog/server/db/schemas'
 
 // GET /api/admin/posts — Admin post list (page pagination)
@@ -10,6 +10,7 @@ export default defineEventHandler(async (event): Promise<PagePaginatedList<PostL
 
   const query = getQuery(event)
   const sort = (query.sort as string) || 'createdAt'
+  const order = query.order === 'asc' ? 'asc' : 'desc'
   const page = Math.max(Number(query.page) || 1, 1)
   const pageSize = Math.min(Number(query.pageSize) || 10, 100)
   const offset = (page - 1) * pageSize
@@ -19,6 +20,8 @@ export default defineEventHandler(async (event): Promise<PagePaginatedList<PostL
   const whereClause = and(...postFilterConditions(parsePostFilter(query, orgId)))
 
   const sortCol = sort === 'votes' ? post.voteCount : sort === 'comments' ? post.commentCount : post.createdAt
+  // The id tiebreaker follows the same direction, or equal-value rows shift between pages.
+  const orderFn = order === 'asc' ? asc : desc
 
   const [countResult] = await db
     .select({ total: sql<number>`cast(count(*) as int)` })
@@ -44,7 +47,7 @@ export default defineEventHandler(async (event): Promise<PagePaginatedList<PostL
     .from(post)
     .leftJoin(user, eq(post.authorId, user.id))
     .where(whereClause)
-    .orderBy(desc(sortCol), desc(post.id))
+    .orderBy(orderFn(sortCol), orderFn(post.id))
     .limit(pageSize)
     .offset(offset)
 

--- a/server/api/admin/posts/index.get.ts
+++ b/server/api/admin/posts/index.get.ts
@@ -1,4 +1,4 @@
-import { eq, and, desc, sql, isNull, isNotNull } from 'drizzle-orm'
+import { eq, and, desc, sql } from 'drizzle-orm'
 import { post, user } from '#layers/feedlog/server/db/schemas'
 
 // GET /api/admin/posts — Admin post list (page pagination)
@@ -9,9 +9,6 @@ export default defineEventHandler(async (event): Promise<PagePaginatedList<PostL
   const { orgId } = await requireOrgMember(event)
 
   const query = getQuery(event)
-  const boardId = query.boardId as string | undefined
-  const status = query.status as string | undefined
-  const merged = (query.merged as string) || 'canonical_only'
   const sort = (query.sort as string) || 'createdAt'
   const page = Math.max(Number(query.page) || 1, 1)
   const pageSize = Math.min(Number(query.pageSize) || 10, 100)
@@ -19,13 +16,7 @@ export default defineEventHandler(async (event): Promise<PagePaginatedList<PostL
 
   const db = useDB()
 
-  const conditions: any[] = [eq(post.orgId, orgId)]
-  if (boardId) conditions.push(eq(post.boardId, boardId))
-  if (status) conditions.push(eq(post.status, status))
-  if (merged === 'canonical_only') conditions.push(isNull(post.mergedTo))
-  else if (merged === 'merged_only') conditions.push(isNotNull(post.mergedTo))
-  // 'all' — no merge filter
-  const whereClause = and(...conditions)
+  const whereClause = and(...postFilterConditions(parsePostFilter(query, orgId)))
 
   const sortCol = sort === 'votes' ? post.voteCount : sort === 'comments' ? post.commentCount : post.createdAt
 

--- a/server/api/admin/posts/search.get.ts
+++ b/server/api/admin/posts/search.get.ts
@@ -1,4 +1,4 @@
-import { eq, and, desc, sql, isNull, isNotNull } from 'drizzle-orm'
+import { eq, and, desc, sql } from 'drizzle-orm'
 import { post, postSearch, user } from '#layers/feedlog/server/db/schemas'
 
 // GET /api/admin/posts/search — Admin feedback search, semantic within the active
@@ -13,9 +13,7 @@ export default defineEventHandler(async (event): Promise<PagePaginatedList<PostL
 
   const query = getQuery(event)
   const q = ((query.q as string | undefined) ?? '').trim()
-  const boardId = query.boardId as string | undefined
-  const status = query.status as string | undefined
-  const merged = (query.merged as string) || 'canonical_only'
+  const filter = parsePostFilter(query, orgId)
 
   const db = useDB()
 
@@ -45,10 +43,7 @@ export default defineEventHandler(async (event): Promise<PagePaginatedList<PostL
 
   if (q && embedding) {
     const rows = await searchPostsBySemantic(embedding, {
-      orgId,
-      boardId,
-      status,
-      merged: merged as 'canonical_only' | 'merged_only' | 'all',
+      filter,
       limit: ADMIN_SEARCH_LIMIT,
     })
     return flat(rows)
@@ -57,12 +52,7 @@ export default defineEventHandler(async (event): Promise<PagePaginatedList<PostL
   // Fallback (embeddings unavailable): pg_trgm nearest-N over post_search — whole-string
   // `<->` distance, no text threshold, WITHIN the active filters — matching
   // searchSimilarByTrgm. post_search is sync-maintained on post create/update.
-  const conditions: any[] = [eq(post.orgId, orgId)]
-  if (boardId) conditions.push(eq(post.boardId, boardId))
-  if (status) conditions.push(eq(post.status, status))
-  if (merged === 'canonical_only') conditions.push(isNull(post.mergedTo))
-  else if (merged === 'merged_only') conditions.push(isNotNull(post.mergedTo))
-  const whereClause = and(...conditions)
+  const whereClause = and(...postFilterConditions(filter))
 
   const rows = await db
     .select({

--- a/server/api/posts/search.get.ts
+++ b/server/api/posts/search.get.ts
@@ -29,8 +29,7 @@ export default defineEventHandler(async (event) => {
   let rows
   if (embedding) {
     rows = await searchPostsBySemantic(embedding, {
-      orgId,
-      merged: 'canonical_only',
+      filter: { orgId, merged: 'canonical_only' },
       limit: PUBLIC_SEARCH_LIMIT,
     })
   }

--- a/server/utils/postFilterConditions.ts
+++ b/server/utils/postFilterConditions.ts
@@ -1,0 +1,92 @@
+import { and, eq, gte, inArray, isNotNull, isNull, lt, notInArray, or, type SQL } from 'drizzle-orm'
+import { post } from '#layers/feedlog/server/db/schemas'
+
+// Filter conditions shared by the three post query paths: the admin list, the
+// keyword-search fallback, and the semantic search.
+
+const NO_BOARD = 'none'
+
+export interface PostFilter {
+  orgId: string
+  status?: string[]
+  statusNot?: string[]
+  boardId?: string[]
+  boardIdNot?: string[]
+  authorId?: string[]
+  authorIdNot?: string[]
+  createdFrom?: Date
+  createdTo?: Date
+  merged?: 'canonical_only' | 'merged_only' | 'all'
+}
+
+function list(v: unknown): string[] | undefined {
+  if (typeof v !== 'string') return undefined
+  const items = v.split(',').map(s => s.trim()).filter(Boolean)
+  return items.length ? items : undefined
+}
+
+function date(v: unknown): Date | undefined {
+  if (typeof v !== 'string' || !v) return undefined
+  const d = new Date(v)
+  return Number.isNaN(d.getTime()) ? undefined : d
+}
+
+export function parsePostFilter(query: Record<string, unknown>, orgId: string): PostFilter {
+  const statusNot = list(query['status!'])
+  const boardIdNot = list(query['boardId!'])
+  const authorIdNot = list(query['author!'])
+
+  return {
+    orgId,
+    status: statusNot ? undefined : list(query.status),
+    statusNot,
+    boardId: boardIdNot ? undefined : list(query.boardId),
+    boardIdNot,
+    authorId: authorIdNot ? undefined : list(query.author),
+    authorIdNot,
+    createdFrom: date(query.createdFrom),
+    createdTo: date(query.createdTo),
+    merged: query.merged === 'merged_only' || query.merged === 'all' ? query.merged : 'canonical_only',
+  }
+}
+
+// board_id is nullable, so a negation has to name NULL explicitly — SQL's
+// NOT IN drops NULL rows, which would hide every unclassified post.
+function boardCondition(f: PostFilter): SQL | undefined {
+  if (f.boardId?.length) {
+    const ids = f.boardId.filter(v => v !== NO_BOARD)
+    if (!ids.length) return isNull(post.boardId)
+    return ids.length === f.boardId.length
+      ? inArray(post.boardId, ids)
+      : or(inArray(post.boardId, ids), isNull(post.boardId))
+  }
+
+  if (f.boardIdNot?.length) {
+    const ids = f.boardIdNot.filter(v => v !== NO_BOARD)
+    if (!ids.length) return isNotNull(post.boardId)
+    return ids.length === f.boardIdNot.length
+      ? or(isNull(post.boardId), notInArray(post.boardId, ids))
+      : and(isNotNull(post.boardId), notInArray(post.boardId, ids))
+  }
+}
+
+export function postFilterConditions(f: PostFilter): SQL[] {
+  const conditions: SQL[] = [eq(post.orgId, f.orgId)]
+
+  if (f.merged === 'merged_only') conditions.push(isNotNull(post.mergedTo))
+  else if (f.merged !== 'all') conditions.push(isNull(post.mergedTo))
+
+  if (f.status?.length) conditions.push(inArray(post.status, f.status))
+  if (f.statusNot?.length) conditions.push(notInArray(post.status, f.statusNot))
+
+  const board = boardCondition(f)
+  if (board) conditions.push(board)
+
+  if (f.authorId?.length) conditions.push(inArray(post.authorId, f.authorId))
+  if (f.authorIdNot?.length) conditions.push(notInArray(post.authorId, f.authorIdNot))
+
+  if (f.createdFrom) conditions.push(gte(post.createdAt, f.createdFrom))
+  if (f.createdTo) conditions.push(lt(post.createdAt, f.createdTo))
+
+  return conditions
+}

--- a/server/utils/postSemanticSearch.ts
+++ b/server/utils/postSemanticSearch.ts
@@ -1,11 +1,9 @@
-import { and, eq, isNull, isNotNull, sql } from 'drizzle-orm'
+import { and, eq, sql } from 'drizzle-orm'
+import type { PostFilter } from '#layers/feedlog/server/utils/postFilterConditions'
 import { post, postEmbedding, user } from '#layers/feedlog/server/db/schemas'
 
 export interface SemanticOpts {
-  orgId: string
-  boardId?: string
-  status?: string
-  merged?: 'canonical_only' | 'merged_only' | 'all'
+  filter: PostFilter
   maxDistance?: number // cosine-distance cutoff (public threshold); omit = no cutoff
   limit: number
 }
@@ -18,12 +16,7 @@ export async function searchPostsBySemantic(embedding: number[], opts: SemanticO
   const vec = `[${embedding.join(',')}]`
   const distance = sql`${postEmbedding.embedding} <=> ${vec}::vector`
 
-  const conditions = [eq(post.orgId, opts.orgId)]
-  if (opts.merged === 'merged_only') conditions.push(isNotNull(post.mergedTo))
-  else if (opts.merged === 'all') { /* include both — no mergedTo filter */ }
-  else conditions.push(isNull(post.mergedTo)) // default + canonical_only
-  if (opts.boardId) conditions.push(eq(post.boardId, opts.boardId))
-  if (opts.status) conditions.push(eq(post.status, opts.status))
+  const conditions = postFilterConditions(opts.filter)
   if (opts.maxDistance != null) conditions.push(sql`${distance} <= ${opts.maxDistance}`)
 
   return db


### PR DESCRIPTION
What this PR does

  Extends the admin feedback list's filtering from three single-value fields to five fields with multi-select, negation, and a shareable
  URL.

  - Five filter fields — status, board, author, created date, merged state. Status/board/author accept multiple values (OR within a field,
    AND across fields); enum fields support an is not operator that means "none of the selected values".
  - New endpoint GET /api/admin/posts/authors — author candidates for the filter, counted per org and ordered by feedback count.
  - Filter conditions written to the URL — refresh and link-sharing restore the exact view. Negation rides on the parameter name
    (status!=open); dates are day strings resolved in the browser's timezone.
  - Quick-filter rail on the list page, sharing one condition state with the filter chips.
  - Ascending sort — the list could only sort descending; clicking a sorted column header now toggles direction. The id tiebreaker follows
    the sort direction so rows sharing a value don't shift between pages.
  - Layout fixes the above surfaced — the table needed 1000px minimum but only 900px of that was real, and the sidebar/rail did not yield
    when space ran out, so the table scrolled horizontally at 1280–1440px. Column widths now follow measured content, and the sidebar and
    rail step aside at measured breakpoints.

  Filtering applies identically on all three query paths: the regular list, the pg_trgm search fallback, and semantic search.

  Why

  Admins could not answer routine questions with the existing filters: "everything not yet done" needed switching between three statuses one
  at a time, "everything except this board" was inexpressible, and author and date were visible as columns but not filterable. Filter state
  was also lost on every refresh.

  How to review

  Start with server/utils/postFilterConditions.ts — one condition builder shared by all three query paths, so the filter semantics live in a
  single place.

  The one subtle case is boardCondition(): board_id is nullable, and SQL's NOT IN drops NULL rows. Without naming NULL explicitly, "board is
  not X" would silently hide every unclassified post. The none sentinel value covers "no board" on both the positive and negative side.

  app/composables/useFeedbackFilters.ts is pure and framework-free, so it can be exercised without mounting anything. Two deliberate choices
  there:

  - URL serialization is hand-rolled rather than URLSearchParams, which percent-encodes the ! in a parameter name and leaves status%21=open
    in the address bar.
  - createdTo resolves to the next day's midnight, so the range stays half-open while the boundary date reads as inclusive to the user.

  What not to worry about: min-w-[1000px] → 900px and the column width changes look arbitrary but are measured — 900px is where cell content
  starts being squeezed. The breakpoints (1360px, 1160px) are likewise the measured points where the sidebar and rail have to yield, not
  rounded design values.

  Locally: ?status!=open,planned, ?boardId=<id>,none, and ?sort=createdAt&order=asc are the quickest ways to see the three less obvious
  behaviours.

  Checklist

  - [x] Commits are signed off (git commit -s) — all 12
  - [x] Tests pass locally (pnpm build) — build completes; note this repo has no test runner
  - [x] If schema changed, migration was generated — no schema change; the feature reuses existing columns and indexes
  - [x] If public API or env vars changed, README.md / .env.example / docs/deploy/* updated — see note below
  - [x] No secrets, internal URLs, or team member names in the diff — grepped the full diff
