### PR TITLE
fix: use supported upload size limit

### DIFF
--- a/app/components/WidgetEmbed/WidgetEmbedChat.vue
+++ b/app/components/WidgetEmbed/WidgetEmbedChat.vue
@@ -55,7 +55,7 @@ watch(draft, () => {
 // endpoint wants, and uploading early lets a failure surface while the visitor
 // is still composing.
 // Mirrors `ensure.maxSize` in server/api/upload.post.ts.
-const MAX_UPLOAD_MB = 10
+const MAX_UPLOAD_MB = 16
 interface Attachment { key: string, name: string }
 const attachments = ref<Attachment[]>([])
 const pendingUploads = ref(0)

--- a/server/api/upload.post.ts
+++ b/server/api/upload.post.ts
@@ -12,7 +12,7 @@ export default defineEventHandler(async (event) => {
     formKey: 'file',
     multiple: false,
     ensure: {
-      maxSize: '10MB',
+      maxSize: '16MB',
       types: ['image'],
     },
     put: {


### PR DESCRIPTION
## What this PR does

Updates the image upload size limit from the unsupported `10MB` literal to the NuxtHub-supported `16MB` value, and keeps the widget client-side validation message in sync with the server limit.

## Why

`server/api/upload.post.ts` used `ensure.maxSize: '10MB'`, but the typed NuxtHub upload validator only accepts specific binary size literals such as `8MB` and `16MB`. This caused TypeScript to report an invalid upload size literal.

## How to review

Start with `server/api/upload.post.ts`, then check `app/components/WidgetEmbed/WidgetEmbedChat.vue` to confirm the browser-side limit matches the server-side upload limit.

## Checklist

- [x] Commits are signed off (`git commit -s`)
- [ ] Tests pass locally (`pnpm build`)
- [x] If schema changed, migration was generated (`pnpm generate:migration`) and committed
- [x] If public API or env vars changed, `README.md` / `.env.example` / `docs/deploy/*` updated
- [x] No secrets, internal URLs, or team member names in the diff

Local verification:

- `pnpm i18n:check` passes
- Upload type error for `server/api/upload.post.ts` is gone

Note: full typecheck still has unrelated existing errors outside this small diff.