### PR TITLE
feat(guest): let visitors post, vote and comment without signing in

### DIFF
--- a/app/components/UserAvatar.vue
+++ b/app/components/UserAvatar.vue
@@ -1,0 +1,83 @@
+<script setup lang="ts">
+import type { DisplayableAuthor } from '~/composables/useAuthorDisplay'
+import { avatarHue } from '#layers/feedlog/shared/utils/identity'
+
+// The one place that knows what a person looks like in this product.
+//
+// Three rungs, ordered by how much identity we actually hold: an uploaded
+// picture, initials for someone with an account, and a plain glyph for a guest.
+// Colour is derived from the user id at every rung, so colour answers "who" —
+// shape is what answers "does this person have an account", which reads without
+// anyone having to learn a colour rule and survives colour-blindness.
+//
+// Deliberately NOT used for the signed-in user's own chip in the header and
+// sidebar: that one wears the brand accent, and with exactly one of them on
+// screen there is nothing to tell apart.
+
+interface AvatarAuthor extends DisplayableAuthor {
+  image?: string | null
+}
+
+const props = withDefaults(defineProps<{
+  author?: AvatarAuthor | null
+  size?: 4 | 5 | 6 | 8 | 9 | 10
+  shadow?: boolean
+}>(), { author: null, size: 8, shadow: false })
+
+// Callers pass `shadow` rather than a class: a fallthrough class gets merged with
+// the internal one in a different order on the server than in the browser, which
+// Vue reports as a hydration mismatch. One binding, one order, both sides.
+defineOptions({ inheritAttrs: false })
+
+const { authorName, authorInitials } = useAuthorDisplay()
+
+// Spelled out rather than composed: Tailwind only ships classes it can find as
+// literals in the source.
+const SIZES = {
+  4: { box: 'w-4 h-4', text: 'text-[7px]', icon: 9 },
+  5: { box: 'w-5 h-5', text: 'text-[9px]', icon: 11 },
+  6: { box: 'w-6 h-6', text: 'text-[9px]', icon: 13 },
+  8: { box: 'w-8 h-8', text: 'text-xs', icon: 17 },
+  9: { box: 'w-9 h-9', text: 'text-xs', icon: 19 },
+  10: { box: 'w-10 h-10', text: 'text-sm', icon: 21 },
+} as const
+
+const dims = computed(() => SIZES[props.size])
+const hue = computed(() => (props.author?.id ? avatarHue(props.author.id) : 0))
+const isGuest = computed(() => !!props.author?.isAnonymous)
+const hasImage = computed(() => !!props.author?.image)
+</script>
+
+<template>
+  <span
+    role="img"
+    :aria-label="authorName(author)"
+    :title="authorName(author)"
+    :class="[
+      'rounded-full shrink-0 inline-flex items-center justify-center overflow-hidden font-bold select-none',
+      dims.box,
+      dims.text,
+      hasImage ? '' : 'user-avatar',
+      shadow ? 'shadow-sm' : '',
+    ]"
+    :style="hasImage ? undefined : { '--avatar-hue': hue }"
+  >
+    <img v-if="hasImage" :src="author!.image!" alt="" class="w-full h-full object-cover" referrerpolicy="no-referrer">
+    <Icon v-else-if="isGuest" name="lucide:user-round" :size="dims.icon" />
+    <template v-else>{{ authorInitials(author) }}</template>
+  </span>
+</template>
+
+<style scoped>
+/* Low chroma on purpose: the chip has to read as a background element next to
+   whatever primary colour the tenant picked, not compete with it. */
+.user-avatar {
+  background-color: oklch(0.92 0.05 var(--avatar-hue));
+  color: oklch(0.42 0.10 var(--avatar-hue));
+}
+
+.dark .user-avatar {
+  background-color: oklch(0.34 0.05 var(--avatar-hue));
+  color: oklch(0.88 0.09 var(--avatar-hue));
+}
+</style>

--- a/app/components/WidgetEmbed/WidgetEmbedChat.vue
+++ b/app/components/WidgetEmbed/WidgetEmbedChat.vue
@@ -15,7 +15,7 @@ const emit = defineEmits<{
 }>()
 
 const { t } = useI18n()
-const { user, widgetFetch } = inject(widgetEmbedKey)!
+const { user, widgetFetch, ensureIdentity } = inject(widgetEmbedKey)!
 const protocol = inject(widgetProtocolKey)!
 
 type WidgetAiType = 'feedback' | 'support' | 'clarify' | 'unrecognized'
@@ -80,6 +80,12 @@ function onPaste(e: ClipboardEvent) {
 
 async function uploadFiles(files: File[]) {
   if (!files.length) return
+  // An attachment is a write like any other, so it is enough on its own to earn
+  // a guest identity.
+  if (!await ensureIdentity()) {
+    uploadError.value = t('widget.uploadFailed')
+    return
+  }
   uploadError.value = ''
   pendingUploads.value++
   for (const file of files) {
@@ -166,6 +172,12 @@ async function send() {
   const imageFiles = [...attachments.value]
   const images = imageFiles.map(a => a.key)
   if ((!text && !images.length) || sending.value || uploading.value) return
+  // Where a guest is minted: the visitor has now written something, which is the
+  // first moment they are worth a row.
+  if (!await ensureIdentity()) {
+    messages.value.push({ role: 'assistant', text: t('widget.sendFailed') })
+    return
+  }
   const history = toHistory()
   messages.value.push({ role: 'user', text, images })
   draft.value = ''

--- a/app/components/changelog/ChangelogReactions.vue
+++ b/app/components/changelog/ChangelogReactions.vue
@@ -15,9 +15,7 @@ const picked = reactive<Record<string, boolean>>({})
 const pickerOpen = ref(false)
 const rootRef = ref<HTMLElement | null>(null)
 
-const { data: session } = useAuthSession()
-const isLoggedIn = computed(() => !!session.value?.user)
-const loginModal = useLoginModal()
+const { ensureIdentity } = useGuestSession()
 
 // Initialize picked state from userReactions
 for (const emoji of props.userReactions) {
@@ -33,9 +31,9 @@ const displayedReactions = computed(() =>
 )
 
 async function toggle(emoji: string) {
-  if (!isLoggedIn.value) {
+  if (!await ensureIdentity('allowVote')) {
     pickerOpen.value = false
-    return loginModal.open()
+    return
   }
 
   const wasActive = picked[emoji]

--- a/app/components/comment/CommentItem.vue
+++ b/app/components/comment/CommentItem.vue
@@ -23,6 +23,8 @@ const emit = defineEmits<{
   unmerge: [postId: string]
 }>()
 
+const { authorName } = useAuthorDisplay()
+
 const isMergedPost = computed(() => props.comment.type === 'mergedPost')
 
 const hasMoreChildren = computed(() => {
@@ -40,8 +42,8 @@ const childReplyAuthorMap = computed(() => {
   if (props.depth) return undefined
   const map = new Map<string, string>()
   for (const child of props.comment.children ?? []) {
-    if (child.author?.name) {
-      map.set(child.id, child.author.name)
+    if (child.author) {
+      map.set(child.id, authorName(child.author))
     }
   }
   return map
@@ -71,9 +73,6 @@ async function handleDelete() {
   emit('delete', props.comment.id)
 }
 
-function initials(name: string | null) {
-  return (name || '?').slice(0, 2).toUpperCase()
-}
 
 </script>
 
@@ -90,21 +89,7 @@ function initials(name: string | null) {
   <div v-else class="relative flex flex-col gap-4">
     <div class="flex gap-4" :class="depth ? 'ml-10' : ''">
       <!-- Avatar -->
-      <img
-        v-if="comment.author?.image"
-        :src="comment.author.image"
-        :alt="comment.author.name"
-        class="shrink-0 rounded-full object-cover shadow-sm"
-        :class="depth ? 'w-8 h-8' : 'w-10 h-10'"
-        referrerpolicy="no-referrer"
-      >
-      <div
-        v-else
-        class="shrink-0 rounded-full bg-foreground/10 flex items-center justify-center text-foreground font-bold shadow-sm"
-        :class="depth ? 'w-8 h-8 text-xs' : 'w-10 h-10 text-sm'"
-      >
-        {{ initials(comment.author?.name) }}
-      </div>
+      <UserAvatar :author="comment.author" :size="depth ? 8 : 10" shadow />
 
       <!-- Content -->
       <div
@@ -113,7 +98,7 @@ function initials(name: string | null) {
       >
         <div class="flex items-center gap-2 mb-2">
           <span class="font-heading font-bold" :class="depth ? 'text-xs' : 'text-sm'">
-            {{ comment.author?.name ?? $t('common.anonymous') }}
+            {{ authorName(comment.author) }}
           </span>
           <span
             v-if="comment.author?.isAdmin"

--- a/app/components/comment/MergedPostCard.vue
+++ b/app/components/comment/MergedPostCard.vue
@@ -59,9 +59,7 @@ async function loadMoreSubComments() {
 // Track lazily-loaded comments for second-level merged posts (keyed by post id)
 const level2Comments = ref<Record<string, { data: any[]; loading: boolean; cursor: string | null }>>({})
 
-function initials(name: string | null) {
-  return (name || '?').slice(0, 2).toUpperCase()
-}
+const { authorName } = useAuthorDisplay()
 
 function handleUnmerge() {
   const postId = mp.value?.post.id
@@ -96,26 +94,17 @@ async function loadLevel2Comments(postId: string) {
     <div class="flex gap-4">
       <!-- Avatar -->
       <div class="w-10 h-10 rounded-full shrink-0 flex items-center justify-center shadow-sm relative overflow-visible">
-        <img
-          v-if="comment.author.image"
-          :src="comment.author.image"
-          :alt="comment.author.name"
-          class="w-10 h-10 rounded-full object-cover"
-          referrerpolicy="no-referrer"
-        >
-        <div v-else class="w-10 h-10 rounded-full bg-foreground/10 flex items-center justify-center text-foreground font-bold text-sm">
-          {{ initials(comment.author.name) }}
-        </div>
+        <UserAvatar :author="comment.author" :size="10" />
       </div>
 
       <div class="flex-1 min-w-0">
         <!-- Header with merge badge -->
         <div class="flex items-center flex-wrap gap-2 mb-3">
-          <span class="font-heading font-bold text-sm">{{ comment.author.name }}</span>
+          <span class="font-heading font-bold text-sm">{{ authorName(comment.author) }}</span>
           <span class="text-xs text-muted-foreground">{{ timeAgo(comment.createdAt) }}</span>
           <span class="text-xs font-bold text-primary bg-primary/10 px-2 py-0.5 rounded-md flex items-center gap-1 ml-1">
             <Icon name="lucide:git-merge" size="14" />
-            {{ $t('post.merge.mergedPostBy', { name: comment.author.name }) }}
+            {{ $t('post.merge.mergedPostBy', { name: authorName(comment.author) }) }}
           </span>
 
           <!-- Admin unmerge menu -->
@@ -150,20 +139,11 @@ async function loadLevel2Comments(postId: string) {
         <!-- Second-level merged post card -->
         <div v-if="sc.type === 'mergedPost' && sc.mergedPost?.post" class="flex gap-4">
           <div class="w-10 h-10 rounded-full shrink-0 flex items-center justify-center shadow-sm relative z-10">
-            <img
-              v-if="sc.author.image"
-              :src="sc.author.image"
-              :alt="sc.author.name"
-              class="w-10 h-10 rounded-full object-cover"
-              referrerpolicy="no-referrer"
-            >
-            <div v-else class="w-10 h-10 rounded-full bg-foreground/10 flex items-center justify-center text-foreground font-bold text-sm">
-              {{ initials(sc.author.name) }}
-            </div>
+            <UserAvatar :author="sc.author" :size="10" />
           </div>
           <div class="flex-1 min-w-0">
             <div class="flex items-center flex-wrap gap-2 mb-3">
-              <span class="font-heading font-bold text-sm">{{ sc.author.name }}</span>
+              <span class="font-heading font-bold text-sm">{{ authorName(sc.author) }}</span>
               <span class="text-xs text-muted-foreground">{{ timeAgo(sc.createdAt) }}</span>
               <span class="text-xs font-bold text-primary bg-primary/10 px-2 py-0.5 rounded-md flex items-center gap-1 ml-1">
                 <Icon name="lucide:git-merge" size="14" />
@@ -196,12 +176,11 @@ async function loadLevel2Comments(postId: string) {
             <div v-if="level2Comments[sc.mergedPost.post.id]?.data?.length" class="mt-3 space-y-3">
               <div v-for="l2c in level2Comments[sc.mergedPost.post.id].data" :key="l2c.id" class="flex gap-3">
                 <div class="w-8 h-8 rounded-full shrink-0 flex items-center justify-center shadow-sm">
-                  <img v-if="l2c.author.image" :src="l2c.author.image" :alt="l2c.author.name" class="w-8 h-8 rounded-full object-cover" referrerpolicy="no-referrer">
-                  <div v-else class="w-8 h-8 rounded-full bg-foreground/10 flex items-center justify-center text-foreground font-bold text-xs">{{ initials(l2c.author.name) }}</div>
+                  <UserAvatar :author="l2c.author" :size="8" />
                 </div>
                 <div class="flex-1 min-w-0 bg-card border border-border rounded-lg p-3 shadow-sm">
                   <div class="flex items-center gap-2 mb-1">
-                    <span class="font-heading font-bold text-xs">{{ l2c.author.name }}</span>
+                    <span class="font-heading font-bold text-xs">{{ authorName(l2c.author) }}</span>
                     <span class="text-[10px] text-muted-foreground">{{ timeAgo(l2c.createdAt) }}</span>
                   </div>
                   <p class="text-sm text-foreground/90">{{ l2c.content }}</p>
@@ -225,20 +204,11 @@ async function loadLevel2Comments(postId: string) {
         <!-- Regular sub-comment -->
         <div v-else class="flex gap-4">
           <div class="w-10 h-10 rounded-full shrink-0 flex items-center justify-center shadow-sm relative z-10">
-            <img
-              v-if="sc.author.image"
-              :src="sc.author.image"
-              :alt="sc.author.name"
-              class="w-10 h-10 rounded-full object-cover"
-              referrerpolicy="no-referrer"
-            >
-            <div v-else class="w-10 h-10 rounded-full bg-foreground/10 flex items-center justify-center text-foreground font-bold text-sm">
-              {{ initials(sc.author.name) }}
-            </div>
+            <UserAvatar :author="sc.author" :size="10" />
           </div>
           <div class="flex-1 min-w-0 bg-card border border-border rounded-lg p-4 shadow-sm">
             <div class="flex items-center gap-2 mb-2">
-              <span class="font-heading font-bold text-sm">{{ sc.author.name }}</span>
+              <span class="font-heading font-bold text-sm">{{ authorName(sc.author) }}</span>
               <span class="text-xs text-muted-foreground">{{ timeAgo(sc.createdAt) }}</span>
             </div>
             <p class="text-sm text-foreground/90">{{ sc.content }}</p>

--- a/app/components/post/PostDetail.vue
+++ b/app/components/post/PostDetail.vue
@@ -44,17 +44,21 @@ const commentSort = ref<'newest' | 'oldest' | 'top'>('newest')
 
 // Auth & login modal
 const { data: session } = useAuthSession()
-const isLoggedIn = computed(() => !!session.value?.user)
 const loginModal = useLoginModal()
+const { hasAccount, mayAct, ensureIdentity } = useGuestSession()
+// The comment box is offered before an identity exists: a guest is only minted
+// once they actually press submit. Whoever filed the report always keeps the box,
+// switch or no switch — following up on your own feedback is part of filing it,
+// which is the same exception the server makes.
+const isPostAuthor = computed(() => !!session.value?.user?.id && post.value?.author?.id === session.value.user.id)
+const canOpenCommentBox = computed(() => isPostAuthor.value || mayAct('allowComment'))
 
 // Permissions
 const postAuthorId = computed(() => post.value?.author?.id)
 const { canEdit: canEditPost, canDelete: canDeletePost, isOrgManager, showMenu: showPostMenu } = usePermission(postAuthorId, 'post')
 
 
-function initials(name: string | null) {
-  return (name || '?').slice(0, 2).toUpperCase()
-}
+const { authorName } = useAuthorDisplay()
 
 // Board name
 const boardName = computed(() => {
@@ -208,10 +212,10 @@ async function handleSimilarMerge(direction: 'bring' | 'push', targetPost: any) 
 }
 
 // ---- Vote handler ----
-function handleVote() {
+async function handleVote() {
   if (!post.value) return
   if (isMerged.value) return // Block voting on merged posts
-  if (!isLoggedIn.value) return loginModal.open()
+  if (!await ensureIdentity('allowVote')) return
   const p = post.value
   const settled = p.hasVoted ? store.unvote(props.slug) : store.vote(props.slug)
   const syncList = () => emit('updated', { id: p.id, slug: p.slug, voteCount: p.voteCount, hasVoted: p.hasVoted })
@@ -233,6 +237,7 @@ function emitCommentCount() {
 
 // Comment handlers
 async function handleCommentSubmit(content: string, notify: boolean) {
+  if (!isPostAuthor.value && !await ensureIdentity('allowComment')) return
   commentSubmitting.value = true
   try {
     await store.addComment(props.slug, content, { notify })
@@ -245,6 +250,7 @@ async function handleCommentSubmit(content: string, notify: boolean) {
 
 async function handleReplySubmit(content: string) {
   if (!replyingTo.value) return
+  if (!isPostAuthor.value && !await ensureIdentity('allowComment')) return
   commentSubmitting.value = true
   try {
     const { parentId, commentId } = replyingTo.value
@@ -258,7 +264,7 @@ async function handleReplySubmit(content: string) {
 }
 
 function handleReply(commentId: string) {
-  if (!isLoggedIn.value) return loginModal.open()
+  if (!canOpenCommentBox.value) return loginModal.open()
 
   editingCommentId.value = null
   editing.value = false
@@ -274,8 +280,8 @@ function handleReply(commentId: string) {
   }
 }
 
-function handleLike(commentId: string) {
-  if (!isLoggedIn.value) return loginModal.open()
+async function handleLike(commentId: string) {
+  if (!await ensureIdentity('allowVote')) return
 
   const c = comments.value.find(item => item.id === commentId)
     || comments.value.flatMap(item => item.children ?? []).find(ch => ch.id === commentId)
@@ -452,7 +458,7 @@ async function handleShare() {
         <!-- Merge banner (inside discussion, per PRD) -->
         <MergeBanner v-if="isMerged && post.canonicalPost" :canonical-post="post.canonicalPost" />
         <ClientOnly v-if="!isMerged">
-          <CommentEditor v-if="isLoggedIn" ref="commentEditorRef" :loading="commentSubmitting" :can-notify="isOrgManager" @submit="handleCommentSubmit" />
+          <CommentEditor v-if="canOpenCommentBox" ref="commentEditorRef" :loading="commentSubmitting" :can-notify="isOrgManager" @submit="handleCommentSubmit" />
           <CommentLoginPrompt v-else />
         </ClientOnly>
         <div v-if="commentLoading && comments.length === 0" class="space-y-4 pt-2">
@@ -534,11 +540,11 @@ async function handleShare() {
         <div>
           <h4 class="font-heading text-[11px] font-bold text-muted-foreground uppercase tracking-wider mb-3">{{ $t('post.detail.author') }}</h4>
           <div class="flex items-center gap-3">
-            <img v-if="post.author?.image" :src="post.author.image" :alt="post.author.name" class="w-8 h-8 rounded-full object-cover shrink-0" referrerpolicy="no-referrer">
-            <div v-else class="w-8 h-8 rounded-full bg-foreground/10 flex items-center justify-center text-foreground font-bold text-xs shrink-0">{{ initials(post.author?.name) }}</div>
+            <UserAvatar :author="post.author" :size="8" />
             <div class="flex-1 min-w-0">
-              <p class="text-sm font-bold truncate">{{ post.author?.name ?? $t('common.anonymous') }}</p>
-              <!-- No role check here on purpose: the API only ships email to staff. -->
+              <p class="text-sm font-bold truncate">{{ authorName(post.author) }}</p>
+              <!-- No role check here on purpose: the API only ships email to staff,
+                   and never for a guest — their address is a placeholder. -->
               <div v-if="post.author?.email" class="flex items-center gap-1">
                 <a
                   :href="`mailto:${post.author.email}`"
@@ -557,7 +563,7 @@ async function handleShare() {
           </div>
         </div>
         <!-- Admins never receive post-thread email, so the card would lie to them. -->
-        <PostSubscribeCard v-if="post.id && isLoggedIn && !isOrgManager && !isMerged" :post-id="post.id" :subscribed="post.subscribed ?? false" @update:subscribed="post.subscribed = $event" />
+        <PostSubscribeCard v-if="post.id && hasAccount && !isOrgManager && !isMerged" :post-id="post.id" :subscribed="post.subscribed ?? false" @update:subscribed="post.subscribed = $event" />
         <div class="pt-2 flex flex-col gap-2">
           <Button variant="outline" class="text-primary" :disabled="isMerged" :class="isMerged ? 'opacity-50 cursor-not-allowed' : ''" @click="handleShare"><Icon name="lucide:share-2" size="18" /> {{ $t('post.detail.shareRequest') }}</Button>
         </div>

--- a/app/components/post/SubmitModal.vue
+++ b/app/components/post/SubmitModal.vue
@@ -16,11 +16,16 @@ const { t, locale } = useI18n()
 const boardStore = useBoardStore()
 const { boards } = storeToRefs(boardStore)
 
-const { data: session } = useAuthSession()
-const isLoggedIn = computed(() => !!session.value?.user)
 const loginModal = useLoginModal()
+const { hasAccount, guestMay, mayAct, ensureIdentity } = useGuestSession()
 // The user pressed submit while signed out; resume once a session appears.
 const awaitingLogin = ref(false)
+// Shown when this submission will go out under a guest identity — either one is
+// already minted, or one is about to be. Sits directly above the button, at the
+// moment the draft is finished and the hand is moving to submit; below it would
+// be past the end of the reading path. State first, benefit second: the reader's
+// first question is whether they can post at all without an account.
+const showGuestHint = computed(() => !hasAccount.value && guestMay('allowPost'))
 
 const selectedBoardId = ref<string | null>(null)
 const title = ref('')
@@ -108,13 +113,13 @@ async function handleSubmit() {
     return
   }
 
-  // Only reachable from a pre-filled link: every other entry point still gates
-  // on sign-in before opening the form. Arriving with a draft already written
-  // is what earns the deferral — the auth prompt waits until it would cost the
-  // reporter something to walk away.
-  if (!isLoggedIn.value) {
+  // Where a guest identity is minted, if the org allows one — deliberately here
+  // and not on open, so a visitor who changes their mind leaves nothing behind.
+  // When guest posting is off this opens the sign-in modal instead and the draft
+  // waits; that path is reachable from a pre-filled link, where the reporter
+  // arrives already holding text worth not throwing away.
+  if (!await ensureIdentity('allowPost')) {
     awaitingLogin.value = true
-    loginModal.open()
     return
   }
 
@@ -144,8 +149,10 @@ async function handleSubmit() {
 
 // Sign-in happens in place (OAuth runs in a popup, email posts via fetch), so
 // the draft is still in memory here — finish the submit the user already asked
-// for instead of making them press the button twice.
-watch(isLoggedIn, (v) => {
+// for instead of making them press the button twice. Keyed on the account, not
+// on "is signed in": a guest is already signed in, so that would never fire for
+// the visitor this is meant to help.
+watch(hasAccount, (v) => {
   if (!v || !awaitingLogin.value) return
   awaitingLogin.value = false
   void handleSubmit()
@@ -238,6 +245,14 @@ watch(open, (v) => {
         <!-- Error message -->
         <p v-if="error" class="text-sm text-destructive shrink-0">{{ error }}</p>
 
+        <p v-if="showGuestHint" class="text-xs text-muted-foreground shrink-0 -mb-1">
+          {{ $t('post.submit.guestHint.before') }}<button
+            type="button"
+            class="text-primary font-semibold underline underline-offset-2 hover:opacity-80 transition-opacity"
+            @click="loginModal.open()"
+          >{{ $t('post.submit.guestHint.link') }}</button>{{ $t('post.submit.guestHint.after') }}
+        </p>
+
         <!-- Submit button -->
         <button
           class="w-full h-11 bg-primary hover:bg-primary/90 text-primary-foreground text-[15px] font-heading font-bold rounded-[10px] transition-all transform active:scale-[0.99] shadow-lg shadow-primary/20 disabled:opacity-50 disabled:cursor-not-allowed shrink-0"
@@ -245,7 +260,7 @@ watch(open, (v) => {
           @click="handleSubmit"
         >
           <template v-if="submitting">{{ $t('post.submit.submitting') }}</template>
-          <template v-else-if="!isLoggedIn">{{ $t('post.submit.signInAndSubmit') }}</template>
+          <template v-else-if="!mayAct('allowPost')">{{ $t('post.submit.signInAndSubmit') }}</template>
           <template v-else>{{ $t('post.submit.submit') }}</template>
         </button>
       </div>

--- a/app/components/settings/GuestActionsSection.vue
+++ b/app/components/settings/GuestActionsSection.vue
@@ -1,0 +1,116 @@
+<script setup lang="ts">
+import { authClient } from '~/lib/auth-client'
+import type { GuestAction, ResolvedGuestAccess } from '#layers/feedlog/shared/utils/guest'
+import { mergeGuestAccessMetadata, resolveGuestAccess } from '#layers/feedlog/shared/utils/guest'
+import type { OrgMetadataInput } from '#layers/feedlog/shared/utils/branding'
+
+interface OrgRow {
+  id: string
+  metadata: OrgMetadataInput
+}
+
+const props = defineProps<{
+  org: OrgRow
+  isOwner: boolean
+}>()
+
+const emit = defineEmits<{
+  saved: []
+}>()
+
+const { t } = useI18n()
+
+// Only guest posting carries a note. It is the one switch whose reach an admin
+// can't infer from a page titled "organization settings": submitting is the only
+// thing a visitor does in the embedded widget, so this switch alone decides
+// whether the widget works at all for someone who isn't signed in.
+const ROWS: { key: GuestAction; hasNote?: boolean }[] = [
+  { key: 'allowPost', hasNote: true },
+  { key: 'allowVote' },
+  { key: 'allowComment' },
+]
+
+const form = reactive<ResolvedGuestAccess>({ allowPost: false, allowVote: false, allowComment: false })
+const saving = ref(false)
+const error = ref<string | null>(null)
+
+function hydrate() {
+  Object.assign(form, resolveGuestAccess(props.org.metadata))
+  error.value = null
+}
+
+watch(() => props.org, hydrate, { immediate: true })
+
+const current = computed(() => resolveGuestAccess(props.org.metadata))
+const dirty = computed(() => ROWS.some(r => form[r.key] !== current.value[r.key]))
+const canSave = computed(() => props.isOwner && dirty.value && !saving.value)
+
+async function save() {
+  if (!canSave.value) return
+  saving.value = true
+  error.value = null
+  try {
+    await authClient.organization.update({
+      organizationId: props.org.id,
+      data: { metadata: mergeGuestAccessMetadata(props.org.metadata, { ...form }) },
+    })
+    emit('saved')
+  }
+  catch {
+    error.value = t('settings.guest.saveFailed')
+  }
+  finally {
+    saving.value = false
+  }
+}
+</script>
+
+<template>
+  <section class="rounded-xl border border-border bg-card overflow-hidden">
+    <div class="px-6 py-5 border-b border-border">
+      <h3 class="font-heading font-bold text-sm">{{ $t('settings.guest.title') }}</h3>
+      <p class="text-xs text-muted-foreground mt-0.5">{{ $t('settings.guest.subtitle') }}</p>
+    </div>
+
+    <!-- Spacing separates the rows; a second set of rules inside the body would
+         read as another level of nesting under the header's divider. -->
+    <div class="px-6 py-6 space-y-7">
+      <div v-for="row in ROWS" :key="row.key" class="flex items-start justify-between gap-6">
+        <div class="min-w-0">
+          <p class="text-sm font-bold">{{ $t(`settings.guest.${row.key}.title`) }}</p>
+          <p class="text-xs text-muted-foreground mt-1 leading-relaxed">{{ $t(`settings.guest.${row.key}.desc`) }}</p>
+          <p
+            v-if="row.hasNote"
+            class="mt-2 flex items-start gap-1.5 text-[11px] leading-relaxed text-muted-foreground/80"
+          >
+            <Icon name="lucide:info" size="12" class="mt-0.5 shrink-0" />
+            <span>{{ $t(`settings.guest.${row.key}.note`) }}</span>
+          </p>
+        </div>
+        <Switch v-model="form[row.key]" :disabled="!isOwner" class="mt-1 shrink-0" />
+      </div>
+    </div>
+
+    <div class="px-6 py-3 border-t border-border bg-muted/30 flex items-center justify-end gap-3">
+      <p v-if="error" class="text-xs text-red-600 flex items-center gap-1.5 min-w-0 truncate mr-auto">
+        <Icon name="lucide:alert-circle" size="13" class="shrink-0" />
+        {{ error }}
+      </p>
+      <button
+        v-if="dirty"
+        class="h-9 px-4 rounded-lg border border-border bg-background text-xs font-semibold hover:bg-secondary transition-colors"
+        :disabled="saving"
+        @click="hydrate"
+      >
+        {{ $t('settings.reset') }}
+      </button>
+      <button
+        :disabled="!canSave"
+        class="h-9 px-4 rounded-lg bg-primary text-primary-foreground text-xs font-heading font-bold hover:opacity-90 disabled:opacity-40 disabled:cursor-not-allowed transition-all"
+        @click="save"
+      >
+        {{ saving ? $t('settings.saving') : $t('settings.saveChanges') }}
+      </button>
+    </div>
+  </section>
+</template>

--- a/app/components/ui/switch/Switch.vue
+++ b/app/components/ui/switch/Switch.vue
@@ -1,0 +1,38 @@
+<script setup lang="ts">
+import type { SwitchRootEmits, SwitchRootProps } from "reka-ui"
+import type { HTMLAttributes } from "vue"
+import { reactiveOmit } from "@vueuse/core"
+import {
+  SwitchRoot,
+  SwitchThumb,
+  useForwardPropsEmits,
+} from "reka-ui"
+import { cn } from "@/lib/utils"
+
+const props = defineProps<SwitchRootProps & { class?: HTMLAttributes["class"] }>()
+
+const emits = defineEmits<SwitchRootEmits>()
+
+const delegatedProps = reactiveOmit(props, "class")
+
+const forwarded = useForwardPropsEmits(delegatedProps, emits)
+</script>
+
+<template>
+  <SwitchRoot
+    v-slot="slotProps"
+    data-slot="switch"
+    v-bind="forwarded"
+    :class="cn(
+      'peer data-[state=checked]:bg-primary data-[state=unchecked]:bg-input focus-visible:border-ring focus-visible:ring-ring/50 dark:data-[state=unchecked]:bg-input/80 inline-flex h-[1.15rem] w-8 shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none focus-visible:ring-3 disabled:cursor-not-allowed disabled:opacity-50',
+      props.class,
+    )"
+  >
+    <SwitchThumb
+      data-slot="switch-thumb"
+      :class="cn('bg-background dark:data-[state=unchecked]:bg-foreground dark:data-[state=checked]:bg-primary-foreground pointer-events-none block size-4 rounded-full ring-0 transition-transform data-[state=checked]:translate-x-[calc(100%-2px)] data-[state=unchecked]:translate-x-0')"
+    >
+      <slot name="thumb" v-bind="slotProps" />
+    </SwitchThumb>
+  </SwitchRoot>
+</template>

--- a/app/components/ui/switch/index.ts
+++ b/app/components/ui/switch/index.ts
@@ -1,0 +1,1 @@
+export { default as Switch } from "./Switch.vue"

--- a/app/composables/useAuthorDisplay.ts
+++ b/app/composables/useAuthorDisplay.ts
@@ -1,0 +1,32 @@
+import { guestTag } from '#layers/feedlog/shared/utils/identity'
+
+// How an author's name is shown.
+//
+// The name stored on a guest row is English by construction, and `user.name` is a
+// global field that can't carry a locale — so the label is composed here from the
+// user id instead of rendered from the column.
+//
+// The avatar itself lives in <UserAvatar>.
+
+export interface DisplayableAuthor {
+  id?: string | null
+  name?: string | null
+  isAnonymous?: boolean | null
+}
+
+export function useAuthorDisplay() {
+  const { t } = useI18n()
+
+  function authorName(author?: DisplayableAuthor | null): string {
+    if (author?.isAnonymous && author.id) return t('common.guest', { tag: guestTag(author.id) })
+    return author?.name || t('common.anonymous')
+  }
+
+  // Guests never reach this: their avatar is a glyph, because two characters sat
+  // between a comment count and a clock read as a number, not as a person.
+  function authorInitials(author?: DisplayableAuthor | null): string {
+    return (author?.name || '?').slice(0, 2).toUpperCase()
+  }
+
+  return { authorName, authorInitials }
+}

--- a/app/composables/useGuestSession.ts
+++ b/app/composables/useGuestSession.ts
@@ -1,0 +1,165 @@
+import type { GuestAction } from '#layers/feedlog/shared/utils/guest'
+import { GUEST_TOKEN_STORAGE_KEY } from '#layers/feedlog/shared/utils/guest'
+
+// Guest identity for the portal.
+//
+// Minted lazily — nothing happens until the visitor actually writes, so browsing
+// never leaves a user row behind. The raw session token is kept in localStorage
+// because the session cookie is httpOnly: the mint response is the only moment
+// this page can keep a copy, and claiming the content later needs one.
+
+// Module-scoped so two writes racing each other (a vote and a comment, say) share
+// one mint instead of creating two guests.
+let mintInFlight: Promise<boolean> | null = null
+let claimInFlight: Promise<void> | null = null
+
+function readToken(): string | null {
+  try {
+    return localStorage.getItem(GUEST_TOKEN_STORAGE_KEY)
+  }
+  catch {
+    return null
+  }
+}
+
+function writeToken(token: string): void {
+  try {
+    localStorage.setItem(GUEST_TOKEN_STORAGE_KEY, token)
+  }
+  catch {
+    // Private mode. The identity still works for this visit; it just can't be
+    // claimed onto an account later, which beats refusing the write.
+  }
+}
+
+function clearToken(): void {
+  try {
+    localStorage.removeItem(GUEST_TOKEN_STORAGE_KEY)
+  }
+  catch { /* nothing left to do */ }
+}
+
+export function useGuestSession() {
+  const portal = usePortalOrg()
+  // Reads the session already in the payload instead of asking for it again.
+  // useAuthSession() is a useFetch, and its key only dedupes once the answer has
+  // landed — several callers starting inside the same tick each get their own
+  // request. This composable is used by half a dozen components on one page, so
+  // fetching here would multiply that.
+  //
+  // Requires something up the tree to have awaited useAuthSession() first. The
+  // default layout does, and every surface using this sits under it.
+  const { data: session } = useNuxtData<{ user?: { isAnonymous?: boolean } } | null>('auth-session')
+  const loginModal = useLoginModal()
+
+  const isGuest = computed(() => !!session.value?.user?.isAnonymous)
+  // A guest counts as signed in to every API, but the portal chrome must keep
+  // offering a real sign-in — so "holds an account" is its own thing.
+  const hasAccount = computed(() => !!session.value?.user && !isGuest.value)
+  const hasIdentity = computed(() => !!session.value?.user)
+
+  function guestMay(action: GuestAction): boolean {
+    return portal.value.guest[action]
+  }
+
+  // Whether this visitor may do the thing at all. An account holder always may;
+  // everyone else does it as a guest, so it comes down to the org's switches.
+  // Deliberately not keyed on "is signed in": a guest is signed in as far as
+  // every API is concerned and is still governed by the switches.
+  function mayAct(action: GuestAction): boolean {
+    return hasAccount.value || guestMay(action)
+  }
+
+  // better-auth's own route. It sets the signed session cookie itself and hands
+  // back the raw token in the body — the only moment the page can keep a copy,
+  // since the cookie is httpOnly.
+  //
+  // The org's switches are not checked here: this route knows nothing about
+  // organizations. ensureIdentity() below refuses ahead of it, and every write
+  // endpoint refuses again server-side, which is where the switch is actually
+  // enforced.
+  async function doMint(): Promise<boolean> {
+    try {
+      const res = await $fetch<{ token: string | null }>('/api/auth/sign-in/anonymous', {
+        method: 'POST',
+        body: {},
+      })
+      if (res.token) writeToken(res.token)
+      await refreshNuxtData('auth-session')
+      return true
+    }
+    catch {
+      return false
+    }
+  }
+
+  function mint(): Promise<boolean> {
+    const pending = mintInFlight ?? (mintInFlight = doMint().finally(() => { mintInFlight = null }))
+    return pending
+  }
+
+  // Call this before any write. Returns false when the write must not go ahead —
+  // the sign-in modal is already open by then, so the caller just stops.
+  async function ensureIdentity(action: GuestAction): Promise<boolean> {
+    if (hasAccount.value) return true
+    if (!guestMay(action)) {
+      loginModal.open()
+      return false
+    }
+    // Already a guest, and allowed: nothing to mint.
+    if (hasIdentity.value) return true
+    return await mint()
+  }
+
+  async function runClaim(anonymousToken: string): Promise<void> {
+    let moved = false
+    try {
+      const res = await $fetch<{ claimed?: boolean }>('/api/auth/claim-anonymous', {
+        method: 'POST',
+        body: { anonymousToken },
+      })
+      moved = res?.claimed === true
+    }
+    catch (e) {
+      const status = (e as { statusCode?: number })?.statusCode ?? 0
+      // Keep the token only while a retry could plausibly work; the next page
+      // load will try again. Anything else is permanent, and retrying it forever
+      // is worse than losing a claim that was never going to land.
+      if (status === 0 || status === 429 || status >= 500) return
+    }
+    // Cleared only once the call has answered. Clearing it up front would dedupe
+    // across contexts, but it also throws the claim away whenever the context
+    // dies mid-call — and the endpoint is idempotent, so a duplicate costs one
+    // no-op request while a dropped token costs the visitor their content.
+    clearToken()
+
+    // Everything already on screen was rendered before the rows changed owner —
+    // the feedback list keeps showing the guest it was fetched with, and it holds
+    // its posts in a plain ref, so there is no cached key to invalidate. Reload
+    // rather than teach each surface to re-fetch.
+    //
+    // force, because signing in already reloaded once: the auth-reload plugin
+    // fires on the account switch, and reloadNuxtApp leaves a 10-second marker
+    // that makes any further reload of the same path a no-op. Without force this
+    // call is swallowed and the list stays on the guest.
+    //
+    // Safe from looping even so: this only runs when the claim moved something,
+    // and the token is gone by now, so the next load has nothing to claim.
+    if (moved) reloadNuxtApp({ force: true })
+  }
+
+  // Runs once, the first time a real account shows up with a guest token still
+  // stored. Silent by design: the visitor is told nothing, because from their
+  // side nothing happened — their feedback is simply still theirs.
+  function claimIfPending(): void {
+    if (!import.meta.client || !hasAccount.value) return
+    const token = readToken()
+    if (!token) return
+    // The lock is per-realm while the token is shared across the whole origin,
+    // so it only dedupes within this context. Overlap between contexts is left
+    // to the endpoint, which answers a spent token with claimed:false.
+    claimInFlight ??= runClaim(token).finally(() => { claimInFlight = null })
+  }
+
+  return { isGuest, hasAccount, hasIdentity, guestMay, mayAct, ensureIdentity, claimIfPending }
+}

--- a/app/composables/usePortalOrg.ts
+++ b/app/composables/usePortalOrg.ts
@@ -1,11 +1,14 @@
 import type { ResolvedBranding } from '#layers/feedlog/shared/utils/branding'
 import { resolveBranding } from '#layers/feedlog/shared/utils/branding'
+import type { ResolvedGuestAccess } from '#layers/feedlog/shared/utils/guest'
+import { resolveGuestAccess } from '#layers/feedlog/shared/utils/guest'
 
 export interface PortalOrg {
   name: string // org name, or 'FeedLog' for the default org
   logo: string | null
   isDefault: boolean // unconfigured default org → generic share-card copy
   branding: ResolvedBranding
+  guest: ResolvedGuestAccess
 }
 
 // Portal identity for share-card meta. Populated per-request by
@@ -16,5 +19,6 @@ export function usePortalOrg() {
     logo: null,
     isDefault: true,
     branding: resolveBranding(null),
+    guest: resolveGuestAccess(null),
   }))
 }

--- a/app/composables/useWidgetEmbed.ts
+++ b/app/composables/useWidgetEmbed.ts
@@ -1,14 +1,22 @@
 // Session + transport for the embedded widget page. Identity here comes ONLY
-// from the bearer token the SDK passes in the URL fragment — never a cookie.
+// from a bearer token — never a cookie. Two sources, in order: the token the SDK
+// passes in the URL fragment (the product saying who this is), and failing that
+// a guest token this frame minted for itself on an earlier visit.
 
 import type { InjectionKey } from 'vue'
+import { GUEST_TOKEN_STORAGE_KEY } from '#layers/feedlog/shared/utils/guest'
 
 export interface WidgetEmbedUser {
   id: string
   email: string
   name: string
   image: string | null
+  isAnonymous?: boolean
 }
+
+// 'guest' = nobody yet, but the org allows writing without a sign-in, so the
+// composer stays usable and an identity appears on the first send.
+export type WidgetEmbedStatus = 'loading' | 'authenticated' | 'guest' | 'anonymous'
 
 // Captured at module evaluation, NOT in onMounted: vue-router consumes and
 // clears the hash while hydrating, so by the time a component mounts the
@@ -27,10 +35,40 @@ if (import.meta.client) {
   }
 }
 
+function readGuestToken(): string | null {
+  try {
+    return localStorage.getItem(GUEST_TOKEN_STORAGE_KEY)
+  }
+  catch {
+    // Safari blocks storage for a third-party frame outright. The guest identity
+    // then lasts one page load instead of persisting — still better than refusing
+    // the write.
+    return null
+  }
+}
+
+function writeGuestToken(token: string): void {
+  try {
+    localStorage.setItem(GUEST_TOKEN_STORAGE_KEY, token)
+  }
+  catch { /* see readGuestToken */ }
+}
+
+function clearGuestToken(): void {
+  try {
+    localStorage.removeItem(GUEST_TOKEN_STORAGE_KEY)
+  }
+  catch { /* see readGuestToken */ }
+}
+
 export function useWidgetEmbed() {
   const token = ref<string | null>(null)
   const user = ref<WidgetEmbedUser | null>(null)
-  const status = ref<'loading' | 'authenticated' | 'anonymous'>('loading')
+  const status = ref<WidgetEmbedStatus>('loading')
+  // Set from /api/widget/config once it lands. Starts false so a config that
+  // never arrives is read as "no guests", the safe direction.
+  const allowGuest = ref(false)
+  let mintInFlight: Promise<boolean> | null = null
 
   // The ONLY way this page talks to the API. `credentials: 'omit'` is the whole
   // point, and fetch's default ('same-origin') is wrong here: under a same-site
@@ -60,8 +98,32 @@ export function useWidgetEmbed() {
     return await res.json() as T
   }
 
+  async function claimGuest(anonymousToken: string): Promise<void> {
+    try {
+      await widgetFetch('/api/auth/claim-anonymous', {
+        method: 'POST',
+        body: JSON.stringify({ anonymousToken }),
+      })
+    }
+    catch (e) {
+      const statusCode = (e as { statusCode?: number })?.statusCode ?? 0
+      // Keep the token only while a retry could plausibly work; the next frame
+      // load will try again. Anything else is permanent, and retrying it forever
+      // is worse than losing a claim that was never going to land.
+      if (statusCode === 0 || statusCode === 429 || statusCode >= 500) return
+    }
+    // Cleared only once the call has answered. The SDK can drop this iframe
+    // mid-call, and clearing up front would throw the claim away when it does —
+    // the endpoint is idempotent, so a duplicate costs one no-op request while a
+    // dropped token costs the visitor their content.
+    clearGuestToken()
+  }
+
   async function loadSession(): Promise<boolean> {
-    token.value = capturedToken
+    // The product's own token wins: it names a real person, where the stored one
+    // is only whoever last used this browser anonymously.
+    const stored = readGuestToken()
+    token.value = capturedToken ?? stored
     if (!token.value) {
       status.value = 'anonymous'
       return false
@@ -71,17 +133,60 @@ export function useWidgetEmbed() {
       if (!body?.user) throw new Error('no user')
       user.value = body.user
       status.value = 'authenticated'
+      // A stored guest token alongside a product identity means this visitor
+      // filed something before the product knew who they were. Fold it in, once.
+      if (capturedToken && stored && stored !== capturedToken) void claimGuest(stored)
       return true
     }
     catch {
-      // The SDK is expected to silently re-exchange and rebuild the frame.
+      // A dead product token means the SDK re-exchanges and rebuilds the frame.
+      // A dead stored token is just stale — drop it and carry on as nobody.
+      if (!capturedToken) clearGuestToken()
       token.value = null
+      user.value = null
       status.value = 'anonymous'
       return false
     }
   }
 
-  return { token, user, status, widgetFetch, loadSession }
+  async function mint(): Promise<boolean> {
+    try {
+      // credentials omitted as everywhere else here: better-auth still returns the
+      // raw token in the body, and the Set-Cookie it also sends is simply not
+      // stored — which is what this frame wants, being bearer-only.
+      const res = await fetch('/api/auth/sign-in/anonymous', {
+        method: 'POST',
+        credentials: 'omit',
+        headers: { 'Content-Type': 'application/json' },
+        body: '{}',
+      })
+      if (!res.ok) return false
+      const body = await res.json() as { token?: string | null; user?: WidgetEmbedUser | null }
+      if (!body?.token || !body.user) return false
+      token.value = body.token
+      user.value = body.user
+      writeGuestToken(body.token)
+      status.value = 'authenticated'
+      return true
+    }
+    catch {
+      return false
+    }
+  }
+
+  // Call before any write. Mints a guest the first time, so a visitor who opens
+  // the panel and closes it again leaves nothing behind.
+  //
+  // Checks the org's switch first, the same way the portal does. The server
+  // refuses too, but arriving at a refusal the frame could have predicted costs
+  // a wasted guest row and turns a knowable state into a generic send failure.
+  function ensureIdentity(): Promise<boolean> {
+    if (token.value) return Promise.resolve(true)
+    if (!allowGuest.value) return Promise.resolve(false)
+    return mintInFlight ?? (mintInFlight = mint().finally(() => { mintInFlight = null }))
+  }
+
+  return { token, user, status, allowGuest, widgetFetch, loadSession, ensureIdentity }
 }
 
 // Refs are per call: a child calling the composable gets an unauthenticated one.

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -3,7 +3,21 @@ const { signOut } = useAuth()
 const { data: session } = await useAuthSession()
 const localePath = useLocalePath()
 
-const user = computed(() => session.value?.user)
+const { isGuest, hasAccount, claimIfPending } = useGuestSession()
+// A guest is not an account. The header keeps offering sign-in and shows no
+// avatar or sign-out, because the visitor never created the identity behind it.
+const user = computed(() => isGuest.value ? undefined : session.value?.user)
+
+// Fold in anything the visitor wrote as a guest. Silent — from their side
+// nothing happened, their feedback is simply still theirs.
+//
+// On load, not on every flip of `hasAccount`: signing in switches accounts, and
+// the auth-reload plugin hard-reloads the app on that switch. A claim started in
+// the realm being replaced has its request aborted mid-navigation, so it never
+// sees its own answer and never clears the token — and the realm that comes up
+// next claims all over again. Claiming on load puts it in the realm that lives
+// long enough to finish, and every sign-in path ends in one.
+if (hasAccount.value) claimIfPending()
 // SSO sessions (signed in via the customer's product) are end-user only.
 const isSsoSession = computed(
   () => !!(session.value as { session?: { ssoOrgId?: string | null } } | null)?.session?.ssoOrgId,

--- a/app/pages/auth/callback.vue
+++ b/app/pages/auth/callback.vue
@@ -1,6 +1,15 @@
 <script setup lang="ts">
 // This page is the OAuth popup callback target.
 // It notifies the opener window and closes itself.
+
+// No layout: this window lives for one paint and then closes, so the portal
+// chrome has nothing to render here — and running it would double every
+// sign-in side effect the chrome owns. The guest claim is the one that bit:
+// the chrome claims for whatever account it loads with, and this window loads
+// with the account that just signed in, so it claimed the token alongside the
+// opener and then closed before it could clear it.
+definePageMeta({ layout: false })
+
 if (import.meta.client) {
   window.opener?.postMessage({ type: 'auth-callback' }, window.location.origin)
   window.close()

--- a/app/pages/dashboard/feedback.vue
+++ b/app/pages/dashboard/feedback.vue
@@ -174,9 +174,7 @@ function toggleSort(col: 'createdAt' | 'votes' | 'comments') {
 }
 
 
-function initials(name: string | null) {
-  return (name || '?').slice(0, 2).toUpperCase()
-}
+const { authorName } = useAuthorDisplay()
 
 // Pagination
 const pageNumbers = computed(() => {
@@ -407,20 +405,8 @@ function onPostDeleted(postId: string) {
                   <p class="text-[11px] text-muted-foreground truncate mt-0.5">{{ fb.excerpt }}</p>
                   <div class="flex items-center gap-3 mt-1.5 text-[11px] text-muted-foreground">
                     <div class="flex items-center gap-1">
-                      <img
-                        v-if="fb.author?.image"
-                        :src="fb.author.image"
-                        :alt="fb.author.name"
-                        class="w-4 h-4 rounded-full object-cover"
-                        referrerpolicy="no-referrer"
-                      >
-                      <div
-                        v-else
-                        class="w-4 h-4 rounded-full bg-accent flex items-center justify-center text-accent-foreground font-bold text-[7px]"
-                      >
-                        {{ initials(fb.author?.name) }}
-                      </div>
-                      <span class="font-medium">{{ fb.author?.name ?? $t('common.anonymous') }}</span>
+                      <UserAvatar :author="fb.author" :size="4" />
+                      <span class="font-medium">{{ authorName(fb.author) }}</span>
                     </div>
                     <span>{{ formatDate(fb.createdAt) }}</span>
                     <div class="flex items-center gap-0.5">
@@ -505,20 +491,8 @@ function onPostDeleted(postId: string) {
                 <!-- Author -->
                 <td class="px-4 py-4">
                   <div class="flex items-center gap-2">
-                    <img
-                      v-if="fb.author?.image"
-                      :src="fb.author.image"
-                      :alt="fb.author.name"
-                      class="w-6 h-6 rounded-full object-cover shrink-0"
-                      referrerpolicy="no-referrer"
-                    >
-                    <div
-                      v-else
-                      class="w-6 h-6 rounded-full bg-accent flex items-center justify-center text-accent-foreground font-bold text-[9px]"
-                    >
-                      {{ initials(fb.author?.name) }}
-                    </div>
-                    <span class="text-xs font-medium truncate">{{ fb.author?.name ?? $t('common.anonymous') }}</span>
+                    <UserAvatar :author="fb.author" :size="6" />
+                    <span class="text-xs font-medium truncate">{{ authorName(fb.author) }}</span>
                   </div>
                 </td>
                 <!-- Comments -->

--- a/app/pages/dashboard/settings/members.vue
+++ b/app/pages/dashboard/settings/members.vue
@@ -154,9 +154,6 @@ function formatExpiresIn(iso: string | null): string {
   return `${mins}m`
 }
 
-function initials(name: string | undefined): string {
-  return (name ?? '').slice(0, 2).toUpperCase()
-}
 </script>
 
 <template>
@@ -230,16 +227,7 @@ function initials(name: string | undefined): string {
             </div>
             <ul class="divide-y divide-border">
               <li v-for="m in members" :key="m.id" class="px-5 py-3 flex items-center gap-3">
-                <div class="w-9 h-9 rounded-full overflow-hidden bg-muted shrink-0 flex items-center justify-center">
-                  <img
-                    v-if="m.user.image"
-                    :src="m.user.image"
-                    :alt="m.user.name"
-                    class="w-full h-full object-cover"
-                    referrerpolicy="no-referrer"
-                  >
-                  <span v-else class="text-foreground text-xs font-bold">{{ initials(m.user.name) }}</span>
-                </div>
+                <UserAvatar :author="{ id: m.userId, name: m.user.name, image: m.user.image }" :size="9" />
                 <div class="flex-1 min-w-0">
                   <div class="flex items-center gap-2">
                     <p class="text-sm font-bold truncate">{{ m.user.name }}</p>

--- a/app/pages/dashboard/settings/workspace.vue
+++ b/app/pages/dashboard/settings/workspace.vue
@@ -106,6 +106,8 @@ function reset() {
             </div>
           </section>
 
+          <GuestActionsSection :org="org" :is-owner="isOwner" @saved="loadOrg" />
+
           <OrgBrandingSection :org="org" :is-owner="isOwner" @saved="loadOrg" />
         </template>
       </div>

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -6,13 +6,13 @@ const hasWelcome = computed(() => branding.value.welcomeTitle || branding.value.
 
 // Auth & login modal
 const { data: session } = useAuthSession()
-const isLoggedIn = computed(() => !!session.value?.user)
 const isSsoSession = computed(
   () => !!(session.value as { session?: { ssoOrgId?: string | null } } | null)?.session?.ssoOrgId,
 )
 const orgCtx = useOrgContext()
 const canEditPortal = computed(() => !!session.value?.user && !!orgCtx.value.role && !isSsoSession.value)
 const loginModal = useLoginModal()
+const { mayAct, ensureIdentity } = useGuestSession()
 const timeAgo = useTimeAgo()
 
 // Board store
@@ -150,10 +150,6 @@ async function selectBoard(boardId: string | null) {
 // Status configuration (centralized)
 
 
-// User initials
-function initials(name: string | null) {
-  return (name || '?').slice(0, 2).toUpperCase()
-}
 
 // Post detail store
 const postDetailStore = usePostDetailStore()
@@ -162,6 +158,14 @@ const postDetailStore = usePostDetailStore()
 const showDetail = ref(false)
 const showSubmit = ref(false)
 const detailSlug = ref<string | null>(null)
+
+// The composer opens before any identity exists; a guest is only minted when the
+// draft is actually submitted.
+const canOpenSubmit = computed(() => mayAct('allowPost'))
+function openSubmit() {
+  if (!canOpenSubmit.value) return loginModal.open()
+  showSubmit.value = true
+}
 
 // Pre-filled submit links: /?new=1&title=...&body=...&b=...
 // This is the one entry point that opens the form to signed-out visitors — they
@@ -228,7 +232,7 @@ function onPostDeleted(postId: string) {
 
 // Vote / unvote on list items
 async function handleVote(post: PostListItem) {
-  if (!isLoggedIn.value) return loginModal.open()
+  if (!await ensureIdentity('allowVote')) return
   const wasVoted = post.hasVoted
   post.hasVoted = !wasVoted
   post.voteCount += wasVoted ? -1 : 1
@@ -360,7 +364,7 @@ async function handleVote(post: PostListItem) {
       ref="searchToolbar"
       v-model="searchQuery"
       v-model:sort="sortBy"
-      @new-request="isLoggedIn ? (showSubmit = true) : loginModal.open()"
+      @new-request="openSubmit()"
     />
 
     <!-- Post list with loading state -->
@@ -375,7 +379,7 @@ async function handleVote(post: PostListItem) {
         <p class="fl-empty__hint">{{ $t('board.noMatchesHint') }}</p>
         <Button
           class="h-10 px-4 rounded-lg text-[15px] font-heading font-semibold"
-          @click="isLoggedIn ? showSubmit = true : loginModal.open()"
+          @click="openSubmit()"
         >
           <Icon name="lucide:plus" size="18" />
           {{ $t('board.newRequest') }}
@@ -449,10 +453,7 @@ async function handleVote(post: PostListItem) {
               <span>{{ $t('board.comments', { n: p.commentCount }) }}</span>
             </div>
             <div class="flex items-center gap-2">
-              <img v-if="p.author?.image" :src="p.author.image" :alt="p.author.name" class="w-5 h-5 rounded-full object-cover shrink-0" referrerpolicy="no-referrer">
-              <div v-else class="w-5 h-5 rounded-full bg-foreground/10 flex items-center justify-center text-foreground font-bold text-[9px] shrink-0">
-                {{ initials(p.author?.name) }}
-              </div>
+              <UserAvatar :author="p.author" :size="5" />
               <div class="flex items-center gap-1.5">
                 <Icon name="lucide:clock" size="14" />
                 <span>{{ timeAgo(p.createdAt) }}</span>

--- a/app/pages/widget/embed.vue
+++ b/app/pages/widget/embed.vue
@@ -15,7 +15,7 @@ const route = useRoute()
 const { t } = useI18n()
 
 const embed = useWidgetEmbed()
-const { status, widgetFetch, loadSession } = embed
+const { status, allowGuest, widgetFetch, loadSession } = embed
 const protocol = useWidgetProtocol()
 provide(widgetEmbedKey, embed)
 provide(widgetProtocolKey, protocol)
@@ -221,9 +221,7 @@ async function settleView() {
 let panelObserver: ResizeObserver | null = null
 const probeArmed = ref(true)
 
-function onFirstRender() {
-  probeArmed.value = false
-  if (!authed) return
+function watchPanelVisibility() {
   let shown = true
   panelObserver = new ResizeObserver(([entry]) => {
     const now = (entry?.contentRect.height ?? 0) > 0
@@ -233,8 +231,25 @@ function onFirstRender() {
     else resetToRoot()
   })
   panelObserver.observe(document.documentElement)
+}
+
+function onFirstRender() {
+  probeArmed.value = false
+  if (!authed) return
+  watchPanelVisibility()
   void settleView()
 }
+
+// A guest who just sent their first message now has an identity, so the lists
+// and the badge start applying to them. No settleView: they are mid-conversation
+// and resetting to the root would throw them out of it.
+watch(status, (now, before) => {
+  if (now !== 'authenticated' || before !== 'guest') return
+  authed = true
+  watchPanelVisibility()
+  document.addEventListener('visibilitychange', refreshOnVisible)
+  void loadUnread()
+})
 
 // ---- lifecycle -----------------------------------------------------------
 onMounted(async () => {
@@ -248,15 +263,20 @@ onMounted(async () => {
   // failure costs only the brand colour and the name.
   const config = $fetch<{
     org: { name: string, logo: string | null }
+    allowGuest: boolean
     branding: { primary: string, primaryForeground: string }
   }>('/api/widget/config')
     .then((cfg) => {
       applyBrand(cfg.branding)
       org.value = cfg.org
+      allowGuest.value = cfg.allowGuest
     })
     .catch(() => {})
 
   const [signedIn] = await Promise.all([loadSession(), config])
+  // Nobody yet, but writing is allowed: open on the composer rather than the
+  // wall. The identity appears on the first send, not here.
+  if (!signedIn && allowGuest.value) status.value = 'guest'
   authed = signedIn
   if (authed) {
     // Awaited: the SDK hides this frame until ready(), so settling the view
@@ -323,7 +343,7 @@ onUnmounted(() => {
       </button>
     </header>
 
-    <!-- Signed out -->
+    <!-- Signed out, and this org does not accept guests -->
     <div v-if="status === 'anonymous'" class="flex-1 flex flex-col items-center justify-center gap-3 px-8 text-center">
       <Icon name="lucide:message-circle" size="28" class="text-muted-foreground" />
       <p class="font-heading font-bold text-sm">{{ t('widget.loginTitle') }}</p>

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -17,6 +17,7 @@
     "delete": "Delete",
     "save": "Save",
     "anonymous": "Anonymous",
+    "guest": "Guest {tag}",
     "theme": {
       "label": "Theme",
       "auto": "Auto",
@@ -202,6 +203,11 @@
       "signInAndSubmit": "Sign in & Post",
       "dialogTitle": "Submit Feedback",
       "dialogDescription": "Submit new feedback",
+      "guestHint": {
+        "before": "Posting as a guest. ",
+        "link": "Sign in",
+        "after": " to get notified when someone replies."
+      },
       "errors": {
         "selectBoard": "Please select a board",
         "titleRequired": "Title is required",
@@ -612,6 +618,24 @@
         "light": "Light",
         "dark": "Dark"
       }
+    },
+    "guest": {
+      "title": "Guest actions",
+      "subtitle": "What visitors can do without signing in.",
+      "allowPost": {
+        "title": "Guest posting",
+        "desc": "Let visitors submit feedback without signing in.",
+        "note": "Also lets the embedded widget be used without signing in."
+      },
+      "allowVote": {
+        "title": "Guest voting",
+        "desc": "Let visitors upvote posts without signing in."
+      },
+      "allowComment": {
+        "title": "Guest commenting",
+        "desc": "Let visitors comment on other people's posts without signing in."
+      },
+      "saveFailed": "Failed to save guest actions."
     },
     "portal": {
       "title": "Portal",

--- a/i18n/locales/zh.json
+++ b/i18n/locales/zh.json
@@ -17,6 +17,7 @@
     "delete": "删除",
     "save": "保存",
     "anonymous": "匿名",
+    "guest": "访客 {tag}",
     "theme": {
       "label": "主题",
       "auto": "自动",
@@ -202,6 +203,11 @@
       "signInAndSubmit": "登录并发布",
       "dialogTitle": "提交反馈",
       "dialogDescription": "提交新反馈",
+      "guestHint": {
+        "before": "正在以访客身份提交。",
+        "link": "登录",
+        "after": "后可在有人回复时收到通知。"
+      },
       "errors": {
         "selectBoard": "请选择一个看板",
         "titleRequired": "请填写标题",
@@ -612,6 +618,24 @@
         "light": "浅色",
         "dark": "深色"
       }
+    },
+    "guest": {
+      "title": "访客权限",
+      "subtitle": "访客不登录时可以做哪些事。",
+      "allowPost": {
+        "title": "访客提交反馈",
+        "desc": "允许访客不登录就提交反馈。",
+        "note": "开启后，嵌入式 widget 也可免登录使用。"
+      },
+      "allowVote": {
+        "title": "访客投票",
+        "desc": "允许访客不登录就给反馈投票。"
+      },
+      "allowComment": {
+        "title": "访客评论",
+        "desc": "允许访客不登录就评论他人的反馈。"
+      },
+      "saveFailed": "保存访客权限失败。"
     },
     "portal": {
       "title": "门户",

--- a/server/api/admin/posts/index.get.ts
+++ b/server/api/admin/posts/index.get.ts
@@ -42,6 +42,7 @@ export default defineEventHandler(async (event): Promise<PagePaginatedList<PostL
       authorId: post.authorId,
       authorName: user.name,
       authorImage: user.image,
+      authorIsAnonymous: user.isAnonymous,
       createdAt: post.createdAt,
     })
     .from(post)
@@ -63,7 +64,7 @@ export default defineEventHandler(async (event): Promise<PagePaginatedList<PostL
       commentCount: r.commentCount,
       mergedCount: r.mergedCount,
       hasVoted: false,
-      author: { id: r.authorId, name: r.authorName, image: r.authorImage },
+      author: { id: r.authorId, name: r.authorName, image: r.authorImage, isAnonymous: !!r.authorIsAnonymous },
       createdAt: r.createdAt,
     })),
     pagination: { page, pageSize, total: countResult?.total ?? 0 },

--- a/server/api/admin/posts/search.get.ts
+++ b/server/api/admin/posts/search.get.ts
@@ -20,7 +20,8 @@ export default defineEventHandler(async (event): Promise<PagePaginatedList<PostL
   const flat = (rows: Array<{
     id: string; slug: string; title: string; excerpt: string | null; status: string
     boardId: string | null; voteCount: number; commentCount: number; mergedCount: number
-    authorId: string; authorName: string | null; authorImage: string | null; createdAt: Date
+    authorId: string; authorName: string | null; authorImage: string | null
+    authorIsAnonymous: boolean | null; createdAt: Date
   }>): PagePaginatedList<PostListItem> => ({
     data: rows.map(r => ({
       id: r.id,
@@ -33,7 +34,7 @@ export default defineEventHandler(async (event): Promise<PagePaginatedList<PostL
       commentCount: r.commentCount,
       mergedCount: r.mergedCount,
       hasVoted: false,
-      author: { id: r.authorId, name: r.authorName, image: r.authorImage },
+      author: { id: r.authorId, name: r.authorName, image: r.authorImage, isAnonymous: !!r.authorIsAnonymous },
       createdAt: r.createdAt,
     })),
     pagination: { page: 1, pageSize: rows.length, total: rows.length },
@@ -68,6 +69,7 @@ export default defineEventHandler(async (event): Promise<PagePaginatedList<PostL
       authorId: post.authorId,
       authorName: user.name,
       authorImage: user.image,
+      authorIsAnonymous: user.isAnonymous,
       createdAt: post.createdAt,
     })
     .from(post)

--- a/server/api/auth/claim-anonymous.post.ts
+++ b/server/api/auth/claim-anonymous.post.ts
@@ -1,0 +1,61 @@
+import { z } from 'zod/v4'
+import type { ClaimedCounts } from '#layers/feedlog/server/utils/guest-claim'
+
+// POST /api/auth/claim-anonymous — fold a guest identity into the account that
+// just signed in, so nothing written before the sign-in is lost.
+//
+// Two credentials, deliberately: the Authorization header / cookie says who is
+// receiving the content, and the body says which guest is handing it over. Both
+// have to be held by the same browser for the call to do anything.
+//
+// Portal and widget share this route; the only difference is how the receiving
+// identity travels (cookie vs bearer), which better-auth already normalises.
+//
+// Not a better-auth route despite the path — the plugin's own onLinkAccount hook
+// fires on a fixed list of sign-in paths and depends on the anonymous session
+// still being in a cookie, neither of which holds for the widget.
+const RATE_LIMIT = { limit: 10, windowSeconds: 60 }
+
+// Body, not query: a query string lands in access logs and Referer headers, and
+// this value is a live session token until the moment the claim consumes it.
+const claimSchema = z.object({
+  anonymousToken: z.string().min(1),
+})
+
+interface ClaimResponse {
+  claimed: boolean
+  reason?: 'expired-or-already-claimed' | 'same-user'
+  moved?: ClaimedCounts
+}
+
+export default defineEventHandler(async (event): Promise<ClaimResponse> => {
+  const { session: target } = await requireAuthInOrg(event)
+  if (isGuestSession(target)) {
+    throw createError({ statusCode: 400, message: 'Sign in before claiming guest content' })
+  }
+
+  const ip = getRequestIP(event, { xForwardedFor: true }) || 'unknown'
+  if (!await checkRateLimit(`claim-anonymous:${ip}`, RATE_LIMIT)) {
+    throw createError({ statusCode: 429, message: 'Too many claims, try again shortly' })
+  }
+
+  const { anonymousToken } = await readValidatedBody(event, claimSchema.parse)
+
+  const anon = await auth.api.getSession({
+    headers: new Headers({ Authorization: `Bearer ${anonymousToken}` }),
+  })
+  // A stale token in localStorage is the normal case on a second sign-in, not an
+  // error — the client clears it and stops asking.
+  if (!anon) {
+    return { claimed: false, reason: 'expired-or-already-claimed' }
+  }
+  if (!isGuestSession(anon)) {
+    throw createError({ statusCode: 403, message: 'Only a guest identity can be claimed' })
+  }
+  if (anon.user.id === target.user.id) {
+    return { claimed: false, reason: 'same-user' }
+  }
+
+  const moved = await claimGuestContent(anon.user.id, target.user.id)
+  return { claimed: true, moved }
+})

--- a/server/api/changelogs/[id]/reactions.post.ts
+++ b/server/api/changelogs/[id]/reactions.post.ts
@@ -5,6 +5,7 @@ import { reactionSchema } from '#layers/feedlog/shared/schemas/changelog'
 // POST /api/changelogs/:id/reactions — Add reaction (any authenticated user, idempotent).
 export default defineEventHandler(async (event) => {
   const { session, orgId } = await requireAuthInOrg(event)
+  await assertGuestMay(event, session, 'allowVote')
   const id = getRouterParam(event, 'id')!
   const body = await readValidatedBody(event, reactionSchema.parse)
 

--- a/server/api/comments/[id]/like.post.ts
+++ b/server/api/comments/[id]/like.post.ts
@@ -4,6 +4,9 @@ import { commentLike, comment, post } from '#layers/feedlog/server/db/schemas'
 // POST /api/comments/:id/like — Like a comment (any authenticated user, idempotent).
 export default defineEventHandler(async (event) => {
   const { session, orgId } = await requireAuthInOrg(event)
+  // A like is a one-click reaction with no content, the same shape as a post
+  // upvote — so it rides the voting switch, not the commenting one.
+  await assertGuestMay(event, session, 'allowVote')
   const commentId = getRouterParam(event, 'id')!
 
   const db = useDB()

--- a/server/api/portal-identity.get.ts
+++ b/server/api/portal-identity.get.ts
@@ -1,6 +1,8 @@
 import { DEFAULT_ORG_NAME, DEFAULT_ORG_SLUG } from '#layers/feedlog/shared/constants/default-org'
 import type { ResolvedBranding } from '#layers/feedlog/shared/utils/branding'
 import { resolveBranding } from '#layers/feedlog/shared/utils/branding'
+import type { ResolvedGuestAccess } from '#layers/feedlog/shared/utils/guest'
+import { resolveGuestAccess } from '#layers/feedlog/shared/utils/guest'
 
 function resolveLogoUrl(logo: string | null | undefined): string | null {
   if (!logo) return null
@@ -16,6 +18,7 @@ export default defineEventHandler(async (event): Promise<{
   logo: string | null
   isDefault: boolean
   branding: ResolvedBranding
+  guest: ResolvedGuestAccess
 }> => {
   const slug = event.context.orgSlug ?? DEFAULT_ORG_SLUG
   const info = await getOrgInfo(slug)
@@ -26,5 +29,8 @@ export default defineEventHandler(async (event): Promise<{
     logo: resolveLogoUrl(info?.logo),
     isDefault,
     branding: resolveBranding(info?.metadata),
+    // Rides along so the portal knows, on first paint, whether a write should
+    // mint a guest identity or open the sign-in modal.
+    guest: resolveGuestAccess(info?.metadata),
   }
 })

--- a/server/api/posts/[postId]/comments/index.get.ts
+++ b/server/api/posts/[postId]/comments/index.get.ts
@@ -48,6 +48,7 @@ export default defineEventHandler(async (event) => {
         authorId: comment.authorId,
         authorName: user.name,
         authorImage: user.image,
+        authorIsAnonymous: user.isAnonymous,
         content: comment.content,
         editedAt: comment.editedAt,
         createdAt: comment.createdAt,
@@ -108,6 +109,7 @@ export default defineEventHandler(async (event) => {
       authorId: comment.authorId,
       authorName: user.name,
       authorImage: user.image,
+      authorIsAnonymous: user.isAnonymous,
       content: comment.content,
       type: comment.type,
       metadata: comment.metadata,
@@ -136,6 +138,7 @@ export default defineEventHandler(async (event) => {
         authorId: comment.authorId,
         authorName: user.name,
         authorImage: user.image,
+        authorIsAnonymous: user.isAnonymous,
         content: comment.content,
         editedAt: comment.editedAt,
         createdAt: comment.createdAt,
@@ -187,6 +190,7 @@ export default defineEventHandler(async (event) => {
           authorId: post.authorId,
           authorName: user.name,
           authorImage: user.image,
+          authorIsAnonymous: user.isAnonymous,
         })
         .from(post)
         .leftJoin(user, eq(post.authorId, user.id))
@@ -203,6 +207,7 @@ export default defineEventHandler(async (event) => {
           authorId: comment.authorId,
           authorName: user.name,
           authorImage: user.image,
+          authorIsAnonymous: user.isAnonymous,
           content: comment.content,
           type: comment.type,
           metadata: comment.metadata,
@@ -226,7 +231,7 @@ export default defineEventHandler(async (event) => {
         slug: r.slug,
         title: r.title,
         excerpt: r.excerpt,
-        author: { id: r.authorId, name: r.authorName, image: r.authorImage },
+        author: { id: r.authorId, name: r.authorName, image: r.authorImage, isAnonymous: !!r.authorIsAnonymous },
       })
     }
 
@@ -259,6 +264,7 @@ export default defineEventHandler(async (event) => {
           authorId: post.authorId,
           authorName: user.name,
           authorImage: user.image,
+          authorIsAnonymous: user.isAnonymous,
         })
         .from(post)
         .leftJoin(user, eq(post.authorId, user.id))
@@ -270,7 +276,7 @@ export default defineEventHandler(async (event) => {
           title: r.title,
           excerpt: r.excerpt,
           commentCount: r.commentCount,
-          author: { id: r.authorId, name: r.authorName, image: r.authorImage },
+          author: { id: r.authorId, name: r.authorName, image: r.authorImage, isAnonymous: !!r.authorIsAnonymous },
         })
       }
     }
@@ -366,7 +372,7 @@ function formatComment(r: any, adminIds: Set<string>) {
     replyCount: r.replyCount ?? undefined,
     likeCount: r.likeCount,
     hasLiked: r.hasLiked ?? false,
-    author: { id: r.authorId, name: r.authorName, image: r.authorImage, isAdmin: adminIds.has(r.authorId) },
+    author: { id: r.authorId, name: r.authorName, image: r.authorImage, isAnonymous: !!r.authorIsAnonymous, isAdmin: adminIds.has(r.authorId) },
     content: r.content,
     type: r.type ?? 'comment',
     editedAt: r.editedAt,

--- a/server/api/posts/[postId]/comments/index.post.ts
+++ b/server/api/posts/[postId]/comments/index.post.ts
@@ -22,13 +22,20 @@ export default defineEventHandler(async (event) => {
   const db = useDB()
 
   // Verify post exists, belongs to org, and is not merged.
-  const [p] = await db.select({ id: post.id, mergedTo: post.mergedTo, slug: post.slug, title: post.title }).from(post)
+  const [p] = await db.select({ id: post.id, authorId: post.authorId, mergedTo: post.mergedTo, slug: post.slug, title: post.title }).from(post)
     .where(and(eq(post.id, postId), eq(post.orgId, orgId))).limit(1)
   if (!p) {
     throw createError({ statusCode: 404, message: 'Post not found' })
   }
   if (p.mergedTo) {
     throw createError({ statusCode: 403, message: 'Cannot comment on a merged post' })
+  }
+
+  // Guests may always keep talking under their own report — adding a detail or
+  // answering an admin's follow-up is part of filing it. The switch governs
+  // speaking up on other people's posts.
+  if (p.authorId !== session.user.id) {
+    await assertGuestMay(event, session, 'allowComment')
   }
 
   // Determine parent for reply flattening
@@ -104,7 +111,7 @@ export default defineEventHandler(async (event) => {
   }
 
   const [author] = await db
-    .select({ id: user.id, name: user.name, image: user.image })
+    .select({ id: user.id, name: user.name, image: user.image, isAnonymous: user.isAnonymous })
     .from(user)
     .where(eq(user.id, session.user.id))
 
@@ -116,7 +123,11 @@ export default defineEventHandler(async (event) => {
     replyCount: created!.replyCount,
     likeCount: created!.likeCount,
     hasLiked: false,
-    author: { ...(author ?? { id: session.user.id, name: null, image: null }), isAdmin: isActorAdmin(session, orgId) },
+    author: {
+      ...(author ?? { id: session.user.id, name: null, image: null }),
+      isAnonymous: !!author?.isAnonymous,
+      isAdmin: isActorAdmin(session, orgId),
+    },
     content: created!.content,
     editedAt: created!.editedAt,
     createdAt: created!.createdAt,

--- a/server/api/posts/[postId]/index.get.ts
+++ b/server/api/posts/[postId]/index.get.ts
@@ -25,6 +25,7 @@ export default defineEventHandler(async (event): Promise<PostDetail> => {
       authorName: user.name,
       authorImage: user.image,
       authorEmail: user.email,
+      authorIsAnonymous: user.isAnonymous,
       createdAt: post.createdAt,
       updatedAt: post.updatedAt,
     })
@@ -82,7 +83,11 @@ export default defineEventHandler(async (event): Promise<PostDetail> => {
 
   // Gates author.email below: shipping it to end users would hand every
   // reporter's address to anyone who opens a post.
+  //
+  // A guest's address is a reserved-domain placeholder nobody can write to, so it
+  // is withheld from staff as well — showing it only invites someone to try.
   const isStaff = !!getOrgMemberRole(session, orgId)
+  const showAuthorEmail = isStaff && !row.authorIsAnonymous
 
   // If merged, fetch canonical post info
   let canonicalPost: { slug: string; title: string } | undefined
@@ -112,7 +117,8 @@ export default defineEventHandler(async (event): Promise<PostDetail> => {
       id: row.authorId,
       name: row.authorName,
       image: row.authorImage,
-      ...(isStaff ? { email: row.authorEmail } : {}),
+      isAnonymous: !!row.authorIsAnonymous,
+      ...(showAuthorEmail ? { email: row.authorEmail } : {}),
     },
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,

--- a/server/api/posts/[postId]/vote.post.ts
+++ b/server/api/posts/[postId]/vote.post.ts
@@ -5,6 +5,7 @@ import { isActorAdmin } from '#layers/feedlog/shared/utils/notifications'
 // POST /api/posts/:id/vote — Vote on a post (any authenticated user, idempotent).
 export default defineEventHandler(async (event) => {
   const { session, orgId } = await requireAuthInOrg(event)
+  await assertGuestMay(event, session, 'allowVote')
   const postId = getRouterParam(event, 'postId')!
 
   const db = useDB()

--- a/server/api/posts/index.get.ts
+++ b/server/api/posts/index.get.ts
@@ -59,6 +59,7 @@ export default defineEventHandler(async (event): Promise<CursorPaginatedList<Pos
       authorId: post.authorId,
       authorName: user.name,
       authorImage: user.image,
+      authorIsAnonymous: user.isAnonymous,
       createdAt: post.createdAt,
     })
     .from(post)
@@ -94,7 +95,7 @@ export default defineEventHandler(async (event): Promise<CursorPaginatedList<Pos
     commentCount: r.commentCount,
     mergedCount: r.mergedCount,
     hasVoted: votedPostIds.has(r.id),
-    author: { id: r.authorId, name: r.authorName, image: r.authorImage },
+    author: { id: r.authorId, name: r.authorName, image: r.authorImage, isAnonymous: !!r.authorIsAnonymous },
     createdAt: r.createdAt,
   }))
 

--- a/server/api/posts/index.post.ts
+++ b/server/api/posts/index.post.ts
@@ -5,6 +5,7 @@ import { isActorAdmin } from '#layers/feedlog/shared/utils/notifications'
 // POST /api/posts — Create a post (any authenticated user: end-user or staff).
 export default defineEventHandler(async (event) => {
   const { session, orgId } = await requireAuthInOrg(event)
+  await assertGuestMay(event, session, 'allowPost')
 
   const body = await readValidatedBody(event, createPostSchema.parse)
 

--- a/server/api/posts/search.get.ts
+++ b/server/api/posts/search.get.ts
@@ -51,6 +51,7 @@ export default defineEventHandler(async (event) => {
         authorId: post.authorId,
         authorName: user.name,
         authorImage: user.image,
+        authorIsAnonymous: user.isAnonymous,
         createdAt: post.createdAt,
       })
       .from(post)
@@ -83,7 +84,7 @@ export default defineEventHandler(async (event) => {
     commentCount: r.commentCount,
     mergedCount: r.mergedCount,
     hasVoted: votedPostIds.has(r.id),
-    author: { id: r.authorId, name: r.authorName, image: r.authorImage },
+    author: { id: r.authorId, name: r.authorName, image: r.authorImage, isAnonymous: !!r.authorIsAnonymous },
     createdAt: r.createdAt,
   }))
 

--- a/server/api/posts/similar.post.ts
+++ b/server/api/posts/similar.post.ts
@@ -7,8 +7,14 @@ const schema = z.object({
 })
 
 // POST /api/posts/similar — Search similar posts by input text (for submit modal + merge dialog)
+//
+// Session optional, like every other read of this content: the submit modal
+// searches while the reporter types, and a guest identity is only minted once
+// they press submit — so this runs with nobody attached for the whole time the
+// form is being filled in. It returns the same posts the public list already
+// serves; the session only decides whether hasVoted can be filled in.
 export default defineEventHandler(async (event) => {
-  const session = await requireAuth(event)
+  const session = await getUserSession(event)
   const orgId = event.context.orgId!
   const body = await readValidatedBody(event, schema.parse)
 
@@ -16,7 +22,7 @@ export default defineEventHandler(async (event) => {
     ? body.title + '\n' + body.content
     : body.title
 
-  const userId = session.user.id
+  const userId = session?.user.id
   const plainText = stripMarkdown(text)
   const limit = body.limit ?? 3
 

--- a/server/api/roadmap.get.ts
+++ b/server/api/roadmap.get.ts
@@ -43,6 +43,7 @@ export default defineEventHandler(async (event): Promise<RoadmapResponse> => {
         authorId: post.authorId,
         authorName: user.name,
         authorImage: user.image,
+        authorIsAnonymous: user.isAnonymous,
         createdAt: post.createdAt,
       })
       .from(post)
@@ -105,7 +106,7 @@ export default defineEventHandler(async (event): Promise<RoadmapResponse> => {
       commentCount: r.commentCount,
       mergedCount: r.mergedCount,
       hasVoted: votedPostIds.has(r.id),
-      author: { id: r.authorId, name: r.authorName, image: r.authorImage },
+      author: { id: r.authorId, name: r.authorName, image: r.authorImage, isAnonymous: !!r.authorIsAnonymous },
       createdAt: r.createdAt,
     }))
 

--- a/server/api/widget/config.get.ts
+++ b/server/api/widget/config.get.ts
@@ -1,10 +1,12 @@
 import { eq } from 'drizzle-orm'
 import { organizationWidget } from '#layers/feedlog/server/db/schemas'
 import { pickBrandForegroundHex, resolveBranding } from '#layers/feedlog/shared/utils/branding'
+import { resolveGuestAccess } from '#layers/feedlog/shared/utils/guest'
 
 // GET /api/widget/config — anonymous bootstrap for the widget SDK.
 export default defineEventHandler(async (event): Promise<{
   enabled: boolean
+  allowGuest: boolean
   org: { name: string; logo: string | null }
   branding: { primary: string; primaryForeground: string }
 }> => {
@@ -27,11 +29,24 @@ export default defineEventHandler(async (event): Promise<{
 
   const branding = resolveBranding(info?.metadata)
 
+  // Not cached. Every field here is a switch an admin flips expecting it to take
+  // effect: `enabled` kills the widget, `allowGuest` decides whether the frame
+  // offers a composer at all. A stale read hands a visitor a composer they can no
+  // longer post through, and the refusal reaches them as a generic send failure.
+  //
+  // It buys back less than it looks: the SDK's read and the frame's read land in
+  // different browser cache partitions (keyed by top-frame site *and* frame site),
+  // so they never shared an entry — a cold visitor always cost two origin hits,
+  // cached or not. Only repeat page loads inside the window were saved.
+  setResponseHeader(event, 'Cache-Control', 'no-store')
+
   // Both colors are final values — the SDK does no color math, so a light brand
   // must arrive with a dark foreground already picked.
-  setResponseHeader(event, 'Cache-Control', 'public, max-age=60')
   return {
     enabled,
+    // Everything a visitor can do in the widget ends in a post, so guest posting
+    // decides whether the frame shows the composer or a sign-in wall.
+    allowGuest: resolveGuestAccess(info?.metadata).allowPost,
     // The frame wears the customer's name and mark, for the same reason it takes
     // their brand colour from here.
     org: { name: info?.name ?? '', logo: info?.logo || null },

--- a/server/api/widget/messages.post.ts
+++ b/server/api/widget/messages.post.ts
@@ -31,6 +31,9 @@ interface WidgetMessageResponse {
 
 export default defineEventHandler(async (event): Promise<WidgetMessageResponse> => {
   const { session, orgId } = await requireAuthInOrg(event)
+  // Everything a visitor does in the widget ends in a post, so guest posting is
+  // what decides whether the widget works at all without a sign-in.
+  await assertGuestMay(event, session, 'allowPost')
   const userId = session.user.id
 
   if (!await checkRateLimit(`widget-messages:${userId}`, RATE_LIMIT)) {

--- a/server/db/migrations/0011_many_the_stranger.sql
+++ b/server/db/migrations/0011_many_the_stranger.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "user" ADD COLUMN "is_anonymous" boolean DEFAULT false;

--- a/server/db/migrations/meta/0011_snapshot.json
+++ b/server/db/migrations/meta/0011_snapshot.json
@@ -1,0 +1,2274 @@
+{
+  "id": "981ed10f-6a5b-4790-a1d1-6d4ce042a9e1",
+  "prevId": "3363f04c-0290-47c3-8d6b-0945ef1212a0",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board": {
+      "name": "board",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_board_org_position": {
+          "name": "idx_board_org_position",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.changelog": {
+      "name": "changelog",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(300)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(70)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "categories": {
+          "name": "categories",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "cover": {
+          "name": "cover",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_title": {
+          "name": "published_title",
+          "type": "varchar(70)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_content": {
+          "name": "published_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_categories": {
+          "name": "published_categories",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_cover": {
+          "name": "published_cover",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_changelog_org_public": {
+          "name": "idx_changelog_org_public",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"published_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"changelog\".\"published_at\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_changelog_org_admin": {
+          "name": "idx_changelog_org_admin",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"updated_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_changelog_org_slug": {
+          "name": "idx_changelog_org_slug",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_changelog_title_trgm": {
+          "name": "idx_changelog_title_trgm",
+          "columns": [
+            {
+              "expression": "\"title\" gist_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gist",
+          "with": {}
+        },
+        "idx_changelog_content_trgm": {
+          "name": "idx_changelog_content_trgm",
+          "columns": [
+            {
+              "expression": "\"content\" gist_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gist",
+          "with": {}
+        },
+        "idx_changelog_pub_title_trgm": {
+          "name": "idx_changelog_pub_title_trgm",
+          "columns": [
+            {
+              "expression": "\"published_title\" gist_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gist",
+          "with": {}
+        },
+        "idx_changelog_pub_content_trgm": {
+          "name": "idx_changelog_pub_content_trgm",
+          "columns": [
+            {
+              "expression": "\"published_content\" gist_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gist",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.changelog_reaction": {
+      "name": "changelog_reaction",
+      "schema": "",
+      "columns": {
+        "changelog_id": {
+          "name": "changelog_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "changelog_reaction_changelog_id_user_id_emoji_pk": {
+          "name": "changelog_reaction_changelog_id_user_id_emoji_pk",
+          "columns": [
+            "changelog_id",
+            "user_id",
+            "emoji"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comment": {
+      "name": "comment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_to_id": {
+          "name": "reply_to_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_count": {
+          "name": "reply_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "like_count": {
+          "name": "like_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'comment'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edited_at": {
+          "name": "edited_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_comment_top_level": {
+          "name": "idx_comment_top_level",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"comment\".\"parent_id\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_comment_top_likes": {
+          "name": "idx_comment_top_likes",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"like_count\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"comment\".\"parent_id\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_comment_children": {
+          "name": "idx_comment_children",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"comment\".\"parent_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comment_like": {
+      "name": "comment_like",
+      "schema": "",
+      "columns": {
+        "comment_id": {
+          "name": "comment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "comment_like_comment_id_user_id_pk": {
+          "name": "comment_like_comment_id_user_id_pk",
+          "columns": [
+            "comment_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation": {
+      "name": "conversation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preview_text": {
+          "name": "preview_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "unread": {
+          "name": "unread",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_conversation_owner": {
+          "name": "idx_conversation_owner",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"last_message_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invitation_org_idx": {
+          "name": "invitation_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitation_email_idx": {
+          "name": "invitation_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member": {
+      "name": "member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "member_userId_idx": {
+          "name": "member_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_org_user_unique": {
+          "name": "member_org_user_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.message": {
+      "name": "message",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "images": {
+          "name": "images",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_message_conversation": {
+          "name": "idx_message_conversation",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_sso": {
+      "name": "organization_sso",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_organization_sso_org": {
+          "name": "idx_organization_sso_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_sso_org_id_organization_id_fk": {
+          "name": "organization_sso_org_id_organization_id_fk",
+          "tableFrom": "organization_sso",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_widget": {
+      "name": "organization_widget",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "support_email": {
+          "name": "support_email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled_builtins": {
+          "name": "disabled_builtins",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "custom_rules": {
+          "name": "custom_rules",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "conversation_retention_days": {
+          "name": "conversation_retention_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 14
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organization_widget_org_id_organization_id_fk": {
+          "name": "organization_widget_org_id_organization_id_fk",
+          "tableFrom": "organization_widget",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post": {
+      "name": "post",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(300)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "excerpt": {
+          "name": "excerpt",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote_count": {
+          "name": "vote_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "comment_count": {
+          "name": "comment_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "merged_to": {
+          "name": "merged_to",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_post_org_created": {
+          "name": "idx_post_org_created",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_post_org_votes": {
+          "name": "idx_post_org_votes",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"vote_count\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_post_org_board_created": {
+          "name": "idx_post_org_board_created",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_post_org_board_votes": {
+          "name": "idx_post_org_board_votes",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"vote_count\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_post_org_board_status": {
+          "name": "idx_post_org_board_status",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_post_org_status_votes": {
+          "name": "idx_post_org_status_votes",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"vote_count\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_post_org_author_created": {
+          "name": "idx_post_org_author_created",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_post_org_slug": {
+          "name": "idx_post_org_slug",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_post_merged_to": {
+          "name": "idx_post_merged_to",
+          "columns": [
+            {
+              "expression": "merged_to",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"post\".\"merged_to\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_embedding": {
+      "name": "post_embedding",
+      "schema": "",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(768)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_post_embedding_org": {
+          "name": "idx_post_embedding_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "post_embedding_post_id_post_id_fk": {
+          "name": "post_embedding_post_id_post_id_fk",
+          "tableFrom": "post_embedding",
+          "tableTo": "post",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_search": {
+      "name": "post_search",
+      "schema": "",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "search_text": {
+          "name": "search_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_post_search_org": {
+          "name": "idx_post_search_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "post_search_post_id_post_id_fk": {
+          "name": "post_search_post_id_post_id_fk",
+          "tableFrom": "post_search",
+          "tableTo": "post",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_subscription": {
+      "name": "post_subscription",
+      "schema": "",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "post_subscription_post_id_user_id_pk": {
+          "name": "post_subscription_post_id_user_id_pk",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_unread": {
+      "name": "post_unread",
+      "schema": "",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "post_unread_post_id_user_id_pk": {
+          "name": "post_unread_post_id_user_id_pk",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sso_org_id": {
+          "name": "sso_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_anonymous": {
+          "name": "is_anonymous",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vote": {
+      "name": "vote",
+      "schema": "",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "vote_post_id_user_id_pk": {
+          "name": "vote_post_id_user_id_pk",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/server/db/migrations/meta/_journal.json
+++ b/server/db/migrations/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1786443369000,
       "tag": "0010_careful_firebird",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1787188021565,
+      "tag": "0011_many_the_stranger",
+      "breakpoints": true
     }
   ]
 }

--- a/server/db/schemas/auth.ts
+++ b/server/db/schemas/auth.ts
@@ -13,6 +13,10 @@ export const user = pgTable("user", {
     .$onUpdate(() => /* @__PURE__ */ new Date())
     .notNull(),
   role: text("role"),
+  // better-auth anonymous plugin field. True = a guest row minted for someone who
+  // wrote something without signing in; its email is a reserved-domain placeholder.
+  // input:false on the plugin side, so no client can set it through the API.
+  isAnonymous: boolean("is_anonymous").default(false),
   banned: boolean("banned").default(false),
   banReason: text("ban_reason"),
   banExpires: timestamp("ban_expires"),

--- a/server/middleware/sso-session-guard.ts
+++ b/server/middleware/sso-session-guard.ts
@@ -1,18 +1,23 @@
-// Blocks identity elevation on product-SSO sessions.
+// Blocks identity elevation on sessions that were never proven to belong to a
+// person: product-SSO sessions and guest (no sign-in) sessions.
 //
 // An SSO session asserts an org-provided email that FeedLog never verified, so
 // it must not set/change a password, change email, edit profile, or bind a
 // login method — any of which would turn a borrowed email into a fully-owned
-// account. Nor may it reach org-management or admin endpoints: better-auth's
-// organization plugin enforces permission off the member table, and its admin
-// plugin off user.role — both bypass our requireOrg* gates and the host-binding
-// collar, so an SSO session whose email matches an owner/admin could otherwise
-// drive them. Blocking the /api/auth/organization/ and /api/auth/admin/ prefixes
-// wholesale stays robust as better-auth adds endpoints.
+// account. A guest session is the same problem one step further along: its email
+// is a placeholder nobody vouched for, so changing it would hand the guest an
+// address they never proved they own, ready for a later real login to link onto.
 //
-// Keyed on session.ssoOrgId, NOT user.emailVerified: the latter is global and a
-// separate verified login could flip it true for an SSO session to ride on.
-// `auth` is auto-imported.
+// Neither may reach org-management or admin endpoints: better-auth's organization
+// plugin enforces permission off the member table, and its admin plugin off
+// user.role — both bypass our requireOrg* gates and the host-binding collar, so
+// an SSO session whose email matches an owner/admin could otherwise drive them.
+// Blocking the /api/auth/organization/ and /api/auth/admin/ prefixes wholesale
+// stays robust as better-auth adds endpoints.
+//
+// Keyed on session.ssoOrgId / user.isAnonymous, NOT user.emailVerified: the
+// latter is global and a separate verified login could flip it true for an SSO
+// session to ride on. `auth` is auto-imported.
 
 const BLOCKED_AUTH_ENDPOINTS = new Set([
   'set-password',
@@ -24,7 +29,7 @@ const BLOCKED_AUTH_ENDPOINTS = new Set([
   'unlink-account',
 ])
 
-function isBlockedForSso(path: string): boolean {
+function isBlockedPath(path: string): boolean {
   if (!path.startsWith('/api/auth/')) return false
   const rest = path.slice('/api/auth/'.length)
   if (rest.startsWith('organization/') || rest.startsWith('admin/')) return true
@@ -33,14 +38,15 @@ function isBlockedForSso(path: string): boolean {
 }
 
 export default defineEventHandler(async (event) => {
-  if (!isBlockedForSso(event.path)) return
+  if (!isBlockedPath(event.path)) return
 
   const session = await auth.api.getSession({ headers: event.headers })
   const ssoOrgId = (session?.session as { ssoOrgId?: string | null } | undefined)?.ssoOrgId
-  if (ssoOrgId) {
+  const isGuest = !!(session?.user as { isAnonymous?: boolean | null } | undefined)?.isAnonymous
+  if (ssoOrgId || isGuest) {
     throw createError({
       statusCode: 403,
-      message: 'SSO sessions cannot manage credentials, profile, or organization',
+      message: 'This session cannot manage credentials, profile, or organization',
     })
   }
 })

--- a/server/utils/auth.ts
+++ b/server/utils/auth.ts
@@ -42,10 +42,16 @@ export async function requireAuth(event: H3Event) {
 // different org); this closes the same-org coincidence. End-user write paths
 // (requireAuthInOrg) deliberately don't call this — posting/voting/commenting
 // is exactly what an SSO end-user is for.
+// Guests are covered here too: they hold no membership, so the permission checks
+// below would already refuse them, but a guest identity is never staff by
+// construction and saying so up front keeps that from resting on a lookup.
 function assertNotSsoSession(session: Awaited<ReturnType<typeof requireAuth>>) {
   const ssoOrgId = (session.session as { ssoOrgId?: string | null }).ssoOrgId
   if (ssoOrgId) {
     throw createError({ statusCode: 403, message: 'SSO sessions cannot access staff areas' })
+  }
+  if ((session.user as { isAnonymous?: boolean | null }).isAnonymous) {
+    throw createError({ statusCode: 403, message: 'Guest sessions cannot access staff areas' })
   }
 }
 
@@ -123,6 +129,7 @@ export function getOrgMemberRole(
 ): string | null {
   if (!session || !orgId) return null
   if ((session.session as { ssoOrgId?: string | null }).ssoOrgId) return null
+  if ((session.user as { isAnonymous?: boolean | null }).isAnonymous) return null
   const orgList = (session as { orgList?: { orgId: string; role: string }[] }).orgList
   return orgList?.find(o => o.orgId === orgId)?.role ?? null
 }

--- a/server/utils/better-auth.ts
+++ b/server/utils/better-auth.ts
@@ -1,13 +1,15 @@
 import { betterAuth, type BetterAuthOptions } from 'better-auth'
 import { drizzleAdapter } from 'better-auth/adapters/drizzle'
-import { admin, bearer, customSession, organization } from 'better-auth/plugins'
+import { admin, anonymous, bearer, customSession, organization } from 'better-auth/plugins'
 import { defu } from 'defu'
 import { eq } from 'drizzle-orm'
 import { uuidv7 } from 'uuidv7'
 import { db } from '../db'
-import { member, organization as orgTable } from '../db/schemas'
+import { member, organization as orgTable, user as userTable } from '../db/schemas'
 import { ac, contributor, manager, owner } from '../../shared/auth/permissions'
 import { DEFAULT_ORG_ID } from '../../shared/constants/default-org'
+import { GUEST_EMAIL_DOMAIN } from '../../shared/utils/guest'
+import { guestTag } from '../../shared/utils/identity'
 import { hashPassword, verifyPassword } from './password-hash'
 import { consola } from 'consola'
 
@@ -115,6 +117,16 @@ async function bootstrapAfterUserCreate(newUser: { id: string; email: string }) 
   }).onConflictDoNothing()
 }
 
+// The plugin picks the name before the row exists, so the id-derived tag can only
+// be written once it does. One extra UPDATE, on a path that runs at most once per
+// guest — worth it so the dashboard and a raw DB query can tell two guests apart
+// without composing the tag themselves.
+async function nameGuestUser(userId: string) {
+  await db.update(userTable)
+    .set({ name: `Anonymous ${guestTag(userId)}` })
+    .where(eq(userTable.id, userId))
+}
+
 // Extension points for `buildAuthConfig` callers. Granular knobs beat
 // trying to merge BetterAuthOptions wholesale — the organization plugin
 // must be re-instantiated to take new options, plugin arrays can't simply
@@ -169,6 +181,17 @@ export function buildAuthConfig(overrides: AuthConfigOverrides = {}): BetterAuth
     sendInvitationEmail,
   }
   const mergedSocial = defu(overrides.socialProviderOverrides ?? {}, socialProviders) as typeof socialProviders
+  // Guests short-circuit ahead of the override so a deployment that swaps in its
+  // own bootstrap (the SaaS layer does) still gets them named — and never runs
+  // org-membership bootstrap for an identity that can't be a member.
+  const bootstrap = overrides.userCreateAfter ?? bootstrapAfterUserCreate
+  const afterUserCreate = async (newUser: { id: string; email: string; isAnonymous?: boolean | null }) => {
+    if (newUser.isAnonymous) {
+      await nameGuestUser(newUser.id)
+      return
+    }
+    await bootstrap(newUser)
+  }
   return {
     database: drizzleAdapter(db, { provider: 'pg' }),
     emailAndPassword,
@@ -187,6 +210,16 @@ export function buildAuthConfig(overrides: AuthConfigOverrides = {}): BetterAuth
       // base64urlnopad HMAC, which a standard-base64 cookie value would not match.
       bearer(),
       admin(),
+      anonymous({
+        // Reserved by RFC 2606 — nobody can ever register it, so a stray email
+        // aimed at a guest can't land in someone's real inbox.
+        generateRandomEmail: () => `anon-${uuidv7()}@${GUEST_EMAIL_DOMAIN}`,
+        // Posts, votes and comments point at the guest's user id with no foreign
+        // key back to `user`, so the plugin's delete-on-sign-in would leave them
+        // pointing at a row that no longer exists. Claiming moves the content
+        // across and drops the row itself.
+        disableDeleteAnonymousUser: true,
+      }),
       organization(orgOpts),
       customSession(async ({ user, session }) => {
         const orgList = await loadOrgList(user.id)
@@ -207,7 +240,7 @@ export function buildAuthConfig(overrides: AuthConfigOverrides = {}): BetterAuth
     databaseHooks: {
       user: {
         create: {
-          after: overrides.userCreateAfter ?? bootstrapAfterUserCreate,
+          after: afterUserCreate,
         },
       },
     },

--- a/server/utils/guest-claim.ts
+++ b/server/utils/guest-claim.ts
@@ -1,0 +1,143 @@
+import { and, eq, exists, inArray, sql } from 'drizzle-orm'
+import { alias } from 'drizzle-orm/pg-core'
+import {
+  changelogReaction,
+  comment,
+  commentLike,
+  conversation,
+  post,
+  postSubscription,
+  postUnread,
+  user,
+  vote,
+} from '#layers/feedlog/server/db/schemas'
+
+// Moves everything a guest left behind onto the account they just signed in with,
+// then drops the guest row.
+//
+// Not scoped to one org on purpose. Possession of the guest's session token is
+// the whole proof of ownership here, and whoever holds it already controlled that
+// identity everywhere it wrote — narrowing by org would drop content the person
+// legitimately owns without closing anything off.
+//
+// `useDB` is auto-imported by Nitro.
+
+export interface ClaimedCounts {
+  posts: number
+  comments: number
+  votes: number
+  commentLikes: number
+  conversations: number
+}
+
+export async function claimGuestContent(
+  anonUserId: string,
+  targetUserId: string,
+): Promise<ClaimedCounts> {
+  return await useDB().transaction(async (tx) => {
+    // Votes and likes are one-per-user-per-target, so wherever the account has
+    // already reacted the guest's row has nowhere to land. Dropping it leaves the
+    // stored counter counting a reaction that no longer exists — hence the
+    // decrement, and why these two run ahead of the plain renames below.
+    const otherVote = alias(vote, 'existing_vote')
+    const droppedVotes = await tx
+      .delete(vote)
+      .where(and(
+        eq(vote.userId, anonUserId),
+        exists(tx.select({ n: sql`1` }).from(otherVote).where(and(
+          eq(otherVote.postId, vote.postId),
+          eq(otherVote.userId, targetUserId),
+        ))),
+      ))
+      .returning({ postId: vote.postId })
+    if (droppedVotes.length) {
+      await tx.update(post)
+        .set({ voteCount: sql`greatest(${post.voteCount} - 1, 0)` })
+        .where(inArray(post.id, droppedVotes.map(r => r.postId)))
+    }
+
+    const otherLike = alias(commentLike, 'existing_like')
+    const droppedLikes = await tx
+      .delete(commentLike)
+      .where(and(
+        eq(commentLike.userId, anonUserId),
+        exists(tx.select({ n: sql`1` }).from(otherLike).where(and(
+          eq(otherLike.commentId, commentLike.commentId),
+          eq(otherLike.userId, targetUserId),
+        ))),
+      ))
+      .returning({ commentId: commentLike.commentId })
+    if (droppedLikes.length) {
+      await tx.update(comment)
+        .set({ likeCount: sql`greatest(${comment.likeCount} - 1, 0)` })
+        .where(inArray(comment.id, droppedLikes.map(r => r.commentId)))
+    }
+
+    // Same collision, nothing to repair afterwards.
+    const otherSub = alias(postSubscription, 'existing_subscription')
+    await tx.delete(postSubscription).where(and(
+      eq(postSubscription.userId, anonUserId),
+      exists(tx.select({ n: sql`1` }).from(otherSub).where(and(
+        eq(otherSub.postId, postSubscription.postId),
+        eq(otherSub.userId, targetUserId),
+      ))),
+    ))
+
+    const otherUnread = alias(postUnread, 'existing_unread')
+    await tx.delete(postUnread).where(and(
+      eq(postUnread.userId, anonUserId),
+      exists(tx.select({ n: sql`1` }).from(otherUnread).where(and(
+        eq(otherUnread.postId, postUnread.postId),
+        eq(otherUnread.userId, targetUserId),
+      ))),
+    ))
+
+    const otherReaction = alias(changelogReaction, 'existing_reaction')
+    await tx.delete(changelogReaction).where(and(
+      eq(changelogReaction.userId, anonUserId),
+      exists(tx.select({ n: sql`1` }).from(otherReaction).where(and(
+        eq(otherReaction.changelogId, changelogReaction.changelogId),
+        eq(otherReaction.emoji, changelogReaction.emoji),
+        eq(otherReaction.userId, targetUserId),
+      ))),
+    ))
+
+    const posts = await tx.update(post)
+      .set({ authorId: targetUserId })
+      .where(eq(post.authorId, anonUserId))
+      .returning({ id: post.id })
+    const comments = await tx.update(comment)
+      .set({ authorId: targetUserId })
+      .where(eq(comment.authorId, anonUserId))
+      .returning({ id: comment.id })
+    const votes = await tx.update(vote)
+      .set({ userId: targetUserId })
+      .where(eq(vote.userId, anonUserId))
+      .returning({ postId: vote.postId })
+    const commentLikes = await tx.update(commentLike)
+      .set({ userId: targetUserId })
+      .where(eq(commentLike.userId, anonUserId))
+      .returning({ commentId: commentLike.commentId })
+    const conversations = await tx.update(conversation)
+      .set({ userId: targetUserId })
+      .where(eq(conversation.userId, anonUserId))
+      .returning({ id: conversation.id })
+
+    await tx.update(postSubscription).set({ userId: targetUserId }).where(eq(postSubscription.userId, anonUserId))
+    await tx.update(postUnread).set({ userId: targetUserId }).where(eq(postUnread.userId, anonUserId))
+    await tx.update(changelogReaction).set({ userId: targetUserId }).where(eq(changelogReaction.userId, anonUserId))
+
+    // Last, so nothing above is left pointing at a row that is already gone.
+    // Sessions cascade, which is what kills the guest token and turns a repeated
+    // claim into a no-op.
+    await tx.delete(user).where(eq(user.id, anonUserId))
+
+    return {
+      posts: posts.length,
+      comments: comments.length,
+      votes: votes.length,
+      commentLikes: commentLikes.length,
+      conversations: conversations.length,
+    }
+  })
+}

--- a/server/utils/guest.ts
+++ b/server/utils/guest.ts
@@ -1,0 +1,42 @@
+import type { H3Event } from 'h3'
+import type { GuestAction, ResolvedGuestAccess } from '../../shared/utils/guest'
+import { resolveGuestAccess } from '../../shared/utils/guest'
+
+// Server-side half of the guest (no sign-in) switches. `getOrgInfo` and
+// `createError` are auto-imported by Nitro.
+
+// `{ user: object }` rather than a shape naming isAnonymous: the plugin declares
+// that field through its own schema, which better-auth's inferred session type
+// does not carry — the same reason ssoOrgId is read through a cast elsewhere.
+export function isGuestSession(session: { user: object }): boolean {
+  return !!(session.user as { isAnonymous?: boolean | null }).isAnonymous
+}
+
+export async function getGuestAccess(event: H3Event): Promise<ResolvedGuestAccess> {
+  const slug = event.context.orgSlug
+  const info = slug ? await getOrgInfo(slug) : null
+  return resolveGuestAccess(info?.metadata)
+}
+
+const DENIAL: Record<GuestAction, string> = {
+  allowPost: 'Sign in to submit feedback',
+  allowVote: 'Sign in to vote',
+  allowComment: 'Sign in to comment',
+}
+
+// Gate one write behind the org's guest switches. A no-op for anyone signed in —
+// the switches only ever narrow what a guest may do, never a member.
+//
+// 403 with a stable message so the portal can turn a refusal into the sign-in
+// prompt rather than a generic failure toast.
+export async function assertGuestMay(
+  event: H3Event,
+  session: { user: object },
+  action: GuestAction,
+): Promise<void> {
+  if (!isGuestSession(session)) return
+  const access = await getGuestAccess(event)
+  if (!access[action]) {
+    throw createError({ statusCode: 403, message: DENIAL[action] })
+  }
+}

--- a/server/utils/notifications.ts
+++ b/server/utils/notifications.ts
@@ -59,6 +59,10 @@ export async function resolvePostThreadRecipients(orgId: string, postId: string,
     WHERE ps.post_id IN (SELECT id FROM family)
       AND ps.user_id <> ${actorId}
       AND u.email IS NOT NULL
+      -- A guest's address is a reserved-domain placeholder; mailing it would only
+      -- generate bounces. They still get the widget's unread dot, and once they
+      -- claim the content onto a real account the mail starts flowing.
+      AND u.is_anonymous IS NOT TRUE
       ${excludeVoters}
       AND NOT EXISTS (
         SELECT 1 FROM member m

--- a/server/utils/post-create.ts
+++ b/server/utils/post-create.ts
@@ -76,8 +76,9 @@ export async function createPostRecord(
 
 export async function fetchPostAuthor(authorId: string) {
   const [author] = await useDB()
-    .select({ id: user.id, name: user.name, image: user.image })
+    .select({ id: user.id, name: user.name, image: user.image, isAnonymous: user.isAnonymous })
     .from(user)
     .where(eq(user.id, authorId))
-  return author ?? { id: authorId, name: null, image: null }
+  if (!author) return { id: authorId, name: null, image: null, isAnonymous: false }
+  return { ...author, isAnonymous: !!author.isAnonymous }
 }

--- a/server/utils/postSemanticSearch.ts
+++ b/server/utils/postSemanticSearch.ts
@@ -33,6 +33,7 @@ export async function searchPostsBySemantic(embedding: number[], opts: SemanticO
       authorId: post.authorId,
       authorName: user.name,
       authorImage: user.image,
+      authorIsAnonymous: user.isAnonymous,
       createdAt: post.createdAt,
     })
     .from(post)

--- a/server/utils/similar.ts
+++ b/server/utils/similar.ts
@@ -18,7 +18,7 @@ export interface SimilarPost {
   voteCount: number
   commentCount: number
   hasVoted: boolean
-  author: { id: string; name: string | null; image: string | null }
+  author: { id: string; name: string | null; image: string | null; isAnonymous: boolean }
 }
 
 // Search similar posts using pgvector cosine distance
@@ -45,6 +45,7 @@ export async function searchSimilarByEmbedding(
       authorId: post.authorId,
       authorName: user.name,
       authorImage: user.image,
+      authorIsAnonymous: user.isAnonymous,
     })
     .from(post)
     .innerJoin(postEmbedding, eq(post.id, postEmbedding.postId))
@@ -79,6 +80,7 @@ export async function searchSimilarByTrgm(
       authorId: post.authorId,
       authorName: user.name,
       authorImage: user.image,
+      authorIsAnonymous: user.isAnonymous,
     })
     .from(post)
     .innerJoin(postSearch, eq(post.id, postSearch.postId))
@@ -131,6 +133,7 @@ async function attachHasVoted(
     id: string; slug: string; title: string; excerpt: string | null
     status: string; voteCount: number; commentCount: number
     authorId: string; authorName: string | null; authorImage: string | null
+    authorIsAnonymous: boolean | null
   }[],
   userId?: string,
 ): Promise<SimilarPost[]> {
@@ -144,7 +147,7 @@ async function attachHasVoted(
       voteCount: r.voteCount,
       commentCount: r.commentCount,
       hasVoted: false,
-      author: { id: r.authorId, name: r.authorName, image: r.authorImage },
+      author: { id: r.authorId, name: r.authorName, image: r.authorImage, isAnonymous: !!r.authorIsAnonymous },
     }))
   }
 
@@ -168,6 +171,6 @@ async function attachHasVoted(
     voteCount: r.voteCount,
     commentCount: r.commentCount,
     hasVoted: votedSet.has(r.id),
-    author: { id: r.authorId, name: r.authorName, image: r.authorImage },
+    author: { id: r.authorId, name: r.authorName, image: r.authorImage, isAnonymous: !!r.authorIsAnonymous },
   }))
 }

--- a/shared/types/comment.ts
+++ b/shared/types/comment.ts
@@ -2,6 +2,9 @@ export interface CommentAuthor {
   id: string
   name: string | null
   image: string | null
+  // True = written without signing in. The UI ignores `name` in that case and
+  // composes a localized label off the id instead.
+  isAnonymous?: boolean
   isAdmin?: boolean
 }
 

--- a/shared/types/post.ts
+++ b/shared/types/post.ts
@@ -37,6 +37,9 @@ export interface PostAuthor {
   id: string
   name: string | null
   image: string | null
+  // True = written without signing in. The UI ignores `name` in that case and
+  // composes a localized label off the id instead.
+  isAnonymous?: boolean
   // Optional because only the detail endpoint sets it, and only for staff.
   email?: string | null
 }

--- a/shared/utils/guest.ts
+++ b/shared/utils/guest.ts
@@ -1,0 +1,75 @@
+import { z } from 'zod/v4'
+import { type OrgMetadataInput, parseOrgMetadata } from './branding'
+
+// Guest access = the three things a visitor may do without signing in. Stored
+// under organization.metadata.guest rather than in its own table: three booleans
+// an owner flips a handful of times in a workspace's life, on a row the org
+// cache already loads for every request.
+
+export const guestAccessSchema = z.object({
+  allowPost: z.boolean().optional(),
+  allowVote: z.boolean().optional(),
+  allowComment: z.boolean().optional(),
+})
+
+export type GuestAccess = z.infer<typeof guestAccessSchema>
+
+export interface ResolvedGuestAccess {
+  allowPost: boolean
+  allowVote: boolean
+  allowComment: boolean
+}
+
+export type GuestAction = keyof ResolvedGuestAccess
+
+// Everything off by default, so upgrading an existing install never silently
+// opens the portal to unauthenticated writes.
+export const GUEST_ACCESS_DEFAULTS: ResolvedGuestAccess = {
+  allowPost: false,
+  allowVote: false,
+  allowComment: false,
+}
+
+export function parseGuestAccess(metadata: OrgMetadataInput): GuestAccess {
+  const result = guestAccessSchema.safeParse(parseOrgMetadata(metadata).guest)
+  return result.success ? result.data : {}
+}
+
+export function resolveGuestAccess(metadata: OrgMetadataInput): ResolvedGuestAccess {
+  const parsed = parseGuestAccess(metadata)
+  return {
+    allowPost: parsed.allowPost ?? GUEST_ACCESS_DEFAULTS.allowPost,
+    allowVote: parsed.allowVote ?? GUEST_ACCESS_DEFAULTS.allowVote,
+    allowComment: parsed.allowComment ?? GUEST_ACCESS_DEFAULTS.allowComment,
+  }
+}
+
+export function mergeGuestAccessMetadata(
+  metadata: OrgMetadataInput,
+  access: GuestAccess,
+): Record<string, unknown> {
+  return {
+    ...parseOrgMetadata(metadata),
+    guest: guestAccessSchema.parse(access),
+  }
+}
+
+// With all three off there is nothing a guest identity could be used for, so
+// the mint endpoint refuses to create one at all.
+export function guestAccessEnabled(access: ResolvedGuestAccess): boolean {
+  return access.allowPost || access.allowVote || access.allowComment
+}
+
+// Where the browser keeps the guest's raw session token. Shared by the portal and
+// the embedded widget: in a same-site embed the two surfaces are then one guest
+// instead of two. When the browser partitions iframe storage they simply see
+// different buckets, which costs nothing.
+export const GUEST_TOKEN_STORAGE_KEY = 'feedlog:guest:token'
+
+// Placeholder address for guest rows. `.invalid` is reserved by RFC 2606 and can
+// never be registered, so mail aimed at a guest can't reach a real inbox.
+export const GUEST_EMAIL_DOMAIN = 'feedlog.invalid'
+
+export function isGuestEmail(email: string | null | undefined): boolean {
+  return !!email && email.toLowerCase().endsWith(`@${GUEST_EMAIL_DOMAIN}`)
+}

--- a/shared/utils/identity.ts
+++ b/shared/utils/identity.ts
@@ -1,0 +1,27 @@
+// Things derived from a user id rather than stored: they can never drift from
+// the row they describe, and they cost no column.
+
+// FNV-1a folded to 16 bits. Not a hash for security — it only has to be stable
+// and evenly spread across ids.
+export function stableIdHash(seed: string): number {
+  let h = 0x811C9DC5
+  for (let i = 0; i < seed.length; i++) {
+    h ^= seed.charCodeAt(i)
+    h = Math.imul(h, 0x01000193)
+  }
+  return ((h >>> 16) ^ (h & 0xFFFF)) & 0xFFFF
+}
+
+// Short tag appended to a guest's display name, so two guests in one thread read
+// as two people while one guest reads as the same person across their posts.
+export function guestTag(userId: string): string {
+  return stableIdHash(userId).toString(16).padStart(4, '0')
+}
+
+// Hue for the generated avatar, for everyone — not just guests. Colour answers
+// "who is this"; the avatar's shape (picture / initials / glyph) is what answers
+// "how much identity do we have", which reads without learning a colour rule and
+// survives colour-blindness.
+export function avatarHue(userId: string): number {
+  return (stableIdHash(`hue:${userId}`) * 360) >> 16
+}


### PR DESCRIPTION
Let visitors post, vote and comment without signing in

Submitting feedback currently requires an account. That stops most visitors at the door, and it leaves the embedded widget unusable for products that have no user system of their own.

This adds a guest identity, off by default.


## Checklist

- [ ] Commits are signed off (`git commit -s`)
- [x] Tests pass locally (`pnpm build`)
- [x] If schema changed, migration was generated (`pnpm generate:migration`) and committed
- [x] If public API or env vars changed, `README.md` / `.env.example` / `docs/deploy/*` updated
- [x] No secrets, internal URLs, or team member names in the diff
