### PR TITLE
fix(auth): re-sync the profile from the OAuth provider on sign-in

### DIFF
--- a/server/utils/better-auth.ts
+++ b/server/utils/better-auth.ts
@@ -38,17 +38,28 @@ if (!hasOAuth && !emailLoginEnabled) {
   )
 }
 
-const socialProviders: Record<string, { clientId: string; clientSecret: string }> = {}
+// overrideUserInfoOnSignIn re-syncs name / avatar / email from the provider on
+// every OAuth sign-in. FeedLog has no self-serve profile editor, so the provider
+// is the source of truth — without this a rename on their side would stay
+// invisible here forever. Note it only fires on a fresh OAuth callback, not on
+// an existing session.
+const socialProviders: Record<string, {
+  clientId: string
+  clientSecret: string
+  overrideUserInfoOnSignIn: boolean
+}> = {}
 if (hasGoogle) {
   socialProviders.google = {
     clientId: env.GOOGLE_CLIENT_ID!,
     clientSecret: env.GOOGLE_CLIENT_SECRET!,
+    overrideUserInfoOnSignIn: true,
   }
 }
 if (hasGithub) {
   socialProviders.github = {
     clientId: env.GITHUB_CLIENT_ID!,
     clientSecret: env.GITHUB_CLIENT_SECRET!,
+    overrideUserInfoOnSignIn: true,
   }
 }
 


### PR DESCRIPTION
FeedLog has no self-serve profile editor, so the OAuth provider is the source of truth for name / avatar / email. Without overrideUserInfoOnSignIn, a rename on the provider's side stayed invisible here forever — the record was only ever written at first sign-up.

<!--
Thanks for opening a PR! A few quick checks before you submit:

1. Have you signed off your commits? (git commit -s)
   FeedLog uses DCO, not CLA. No form to fill out — just `-s` on every commit.
2. Does your change need a discussion first?
   For anything non-trivial, please link the Issue or Discussion that led to it.
3. Does CI pass locally? `pnpm build` and a docker build are the bare minimum.
-->

## What this PR does

<!-- One or two sentences. Bullets for multi-part changes are fine. -->

## Why

<!-- Link the Issue, Discussion, or describe the user problem. -->

Closes #

## How to review

<!-- Any tips for the reviewer: where to start reading, what to try locally,
what NOT to worry about (e.g. an intentional-but-odd-looking change). -->

## Checklist

- [ ] Commits are signed off (`git commit -s`)
- [x] Tests pass locally (`pnpm build`)
- [x] If schema changed, migration was generated (`pnpm generate:migration`) and committed
- [x] If public API or env vars changed, `README.md` / `.env.example` / `docs/deploy/*` updated
- [x] No secrets, internal URLs, or team member names in the diff
