### PR TITLE
feat: add domain events and mark stable UI actions

### DIFF
--- a/app/components/WidgetEmbed/WidgetEmbedConversationList.vue
+++ b/app/components/WidgetEmbed/WidgetEmbedConversationList.vue
@@ -42,6 +42,7 @@ function rowTitle(c: WidgetConversationItem): string {
     <div class="flex-1 overflow-y-auto">
       <button
         class="w-full flex items-center gap-3.5 px-5 py-3.5 text-left border-b border-border hover:bg-secondary/55 transition-colors"
+        data-fdl-action="widget_my_feedback_open"
         @click="emit('openFeedback')"
       >
         <span class="w-8.5 h-8.5 shrink-0 inline-flex items-center justify-center text-primary">

--- a/app/components/WidgetEmbed/WidgetEmbedFeedbackCard.vue
+++ b/app/components/WidgetEmbed/WidgetEmbedFeedbackCard.vue
@@ -12,6 +12,8 @@ const { t } = useI18n()
 <template>
   <button
     class="w-full text-left mt-2 min-w-[230px] px-3 py-2.5 rounded-md border border-border bg-background hover:border-primary/50 transition-colors group"
+    data-fdl-action="widget_feedback_open"
+    data-fdl-source="ai-card"
     @click="$emit('open')"
   >
     <p class="text-[13px] font-semibold leading-snug">{{ title }}</p>

--- a/app/components/WidgetEmbed/WidgetEmbedFeedbackList.vue
+++ b/app/components/WidgetEmbed/WidgetEmbedFeedbackList.vue
@@ -50,6 +50,8 @@ onUnmounted(() => listObserver?.disconnect())
       <li v-for="item in items" :key="item.id">
         <button
           class="w-full text-left px-3 py-2.5 rounded-md border border-border bg-card hover:border-primary/40 transition-colors group"
+          data-fdl-action="widget_feedback_open"
+          data-fdl-source="list"
           @click="emit('open', item)"
         >
           <div class="flex items-start gap-2">

--- a/app/components/board/BoardSearchToolbar.vue
+++ b/app/components/board/BoardSearchToolbar.vue
@@ -134,6 +134,8 @@ defineExpose({ reset })
         <Button
           v-show="!searchOpenMobile"
           class="h-10 px-4 rounded-lg text-[15px] font-heading font-semibold"
+          data-fdl-action="feedback_composer_open"
+          data-fdl-source="toolbar"
           @click="emit('new-request')"
         >
           <Icon name="lucide:plus" size="18" />

--- a/app/components/changelog/ChangelogReactions.vue
+++ b/app/components/changelog/ChangelogReactions.vue
@@ -124,6 +124,8 @@ function handleDocumentClick(event: MouseEvent) {
         :class="picked[emoji]
           ? 'border-primary bg-primary/12 text-foreground ring-1 ring-primary/30'
           : 'border-border bg-background text-muted-foreground hover:border-primary/50 hover:text-foreground active:bg-secondary/40'"
+        data-fdl-action="changelog_react"
+        data-fdl-source="chip"
         @click="toggle(emoji)"
       >
         <span class="leading-none select-none">{{ emoji }}</span>
@@ -143,6 +145,8 @@ function handleDocumentClick(event: MouseEvent) {
           class="inline-flex h-8 w-8 items-center justify-center rounded-md text-lg hover:bg-secondary/70 active:bg-secondary touch-manipulation transition-colors"
           :class="picked[emoji] ? 'bg-primary/12 text-foreground ring-1 ring-primary/35' : ''"
           :aria-label="$t('changelog.reactWith', { emoji })"
+          data-fdl-action="changelog_react"
+          data-fdl-source="picker"
           @click="toggleFromPicker(emoji)"
         >
           {{ emoji }}

--- a/app/components/comment/CommentEditor.vue
+++ b/app/components/comment/CommentEditor.vue
@@ -72,11 +72,15 @@ defineExpose({ clear })
             {{ $t('common.cancel') }}
           </Button>
           <div class="flex items-center">
+            <!-- Absent while editing: saving an edit is a different action, and
+                 this one button serves both. -->
             <Button
               variant="default"
               size="sm"
               :class="showNotify ? 'rounded-r-none' : ''"
               :disabled="submitDisabled"
+              :data-fdl-action="isEditing ? undefined : 'comment_submit'"
+              :data-fdl-source="isEditing ? undefined : (isReply ? 'reply' : 'post')"
               @click="handleSubmit"
             >
               {{ isEditing ? $t('common.save') : (isReply ? $t('post.comment.reply') : $t('post.comment.comment')) }}

--- a/app/components/post/PostDetail.vue
+++ b/app/components/post/PostDetail.vue
@@ -385,6 +385,8 @@ async function handleShare() {
               :class="post.hasVoted
                 ? 'bg-primary text-primary-foreground border-primary'
                 : 'bg-background text-foreground border-border hover:border-primary hover:text-primary'"
+              data-fdl-action="feedback_vote"
+              data-fdl-source="detail"
               @click="handleVote"
             >
               <Icon name="lucide:chevron-up" size="28" />

--- a/app/components/post/SimilarPostsHint.vue
+++ b/app/components/post/SimilarPostsHint.vue
@@ -43,6 +43,7 @@ function statusConfig(status: string) {
     <!-- Header (toggle) -->
     <button
       class="w-full flex items-center justify-between cursor-pointer select-none px-3.5 py-2.5"
+      data-fdl-action="similar_feedback_open"
       @click="expanded = !expanded"
     >
       <div class="flex items-center gap-2 text-primary">
@@ -73,6 +74,8 @@ function statusConfig(status: string) {
         v-for="sp in similarPosts"
         :key="sp.id"
         class="group cursor-pointer flex flex-col justify-center py-2 px-3.5 hover:bg-secondary/40 transition-colors"
+        data-fdl-action="feedback_open"
+        data-fdl-source="similar-list"
         @click="emit('select', sp)"
       >
         <div class="flex items-center justify-between gap-3">

--- a/app/components/post/SubmitModal.vue
+++ b/app/components/post/SubmitModal.vue
@@ -257,6 +257,7 @@ watch(open, (v) => {
         <button
           class="w-full h-11 bg-primary hover:bg-primary/90 text-primary-foreground text-[15px] font-heading font-bold rounded-[10px] transition-all transform active:scale-[0.99] shadow-lg shadow-primary/20 disabled:opacity-50 disabled:cursor-not-allowed shrink-0"
           :disabled="submitting"
+          data-fdl-action="feedback_submit"
           @click="handleSubmit"
         >
           <template v-if="submitting">{{ $t('post.submit.submitting') }}</template>

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -379,6 +379,8 @@ async function handleVote(post: PostListItem) {
         <p class="fl-empty__hint">{{ $t('board.noMatchesHint') }}</p>
         <Button
           class="h-10 px-4 rounded-lg text-[15px] font-heading font-semibold"
+          data-fdl-action="feedback_composer_open"
+          data-fdl-source="empty-state"
           @click="openSubmit()"
         >
           <Icon name="lucide:plus" size="18" />
@@ -397,6 +399,8 @@ async function handleVote(post: PostListItem) {
         v-for="p in posts"
         :key="p.id"
         class="feedback-card flex items-stretch gap-4 bg-card border border-border rounded-lg p-4 cursor-pointer"
+        data-fdl-action="feedback_open"
+        data-fdl-source="board-list"
         @click="openPostDetail(p)"
       >
         <!-- Upvote button -->
@@ -405,6 +409,8 @@ async function handleVote(post: PostListItem) {
           :class="p.hasVoted
             ? 'bg-primary text-primary-foreground border-primary shadow-sm'
             : 'bg-background text-foreground border-border hover:border-primary hover:text-primary transition-colors'"
+          data-fdl-action="feedback_vote"
+          data-fdl-source="board-list"
           @click.stop="handleVote(p)"
         >
           <Icon name="lucide:chevron-up" size="24" />

--- a/app/pages/widget/embed.vue
+++ b/app/pages/widget/embed.vue
@@ -337,6 +337,7 @@ onUnmounted(() => {
       <button
         class="w-6.5 h-6.5 rounded-full bg-secondary hover:opacity-80 transition-opacity flex items-center justify-center text-primary shrink-0"
         :aria-label="t('widget.close')"
+        data-fdl-action="widget_panel_close"
         @click="protocol.requestClose()"
       >
         <Icon name="lucide:x" size="13" />

--- a/server/api/posts/index.post.ts
+++ b/server/api/posts/index.post.ts
@@ -1,4 +1,3 @@
-import { getRequestURL } from 'h3'
 import { createPostSchema } from '#layers/feedlog/shared/schemas/post'
 import { isActorAdmin } from '#layers/feedlog/shared/utils/notifications'
 
@@ -18,24 +17,12 @@ export default defineEventHandler(async (event) => {
     subscribeAuthor: !isActorAdmin(session, orgId),
   })
 
-  // Async embedding generation (non-blocking)
-  event.waitUntil(
-    generatePostEmbedding(created.id, orgId, body.title, body.content, created.contentHash),
-  )
-
-  if (!isActorAdmin(session, orgId)) {
-    event.waitUntil(
-      emitAdminNotification({
-        orgId,
-        typeKey: 'post.created',
-        postSlug: created.slug,
-        postTitle: created.title,
-        snippet: body.content,
-        actorId: session.user.id,
-        requestOrigin: getRequestURL(event).origin,
-      }).catch((err: unknown) => console.error('[notifications] post created emit failed', err)),
-    )
-  }
+  publishDomainEvent(event, createDomainEvent({
+    name: 'feedback.created',
+    orgId,
+    userId: session.user.id,
+    data: { feedbackId: created.id, boardId: created.boardId, source: 'portal', messageId: null },
+  }))
 
   const author = await fetchPostAuthor(session.user.id)
 

--- a/server/api/widget/messages.post.ts
+++ b/server/api/widget/messages.post.ts
@@ -1,6 +1,5 @@
 import OpenAI from 'openai'
 import { asc, eq } from 'drizzle-orm'
-import { getRequestURL } from 'h3'
 import { board, conversation, message, organizationWidget } from '#layers/feedlog/server/db/schemas'
 import { buildWidgetSystemPrompt, historyToMessages, parseWidgetAiResponse, parseWidgetHistory } from '#layers/feedlog/server/utils/widget-ai'
 import { CONVERSATION_TOKEN_BUDGET, estimateTokens, isConversationId, ownedConversation } from '#layers/feedlog/server/utils/conversation'
@@ -136,7 +135,7 @@ export default defineEventHandler(async (event): Promise<WidgetMessageResponse> 
   // Stored before the model is asked anything: a failed call then leaves an
   // unanswered message, where writing afterwards would lose what they typed.
   const sentAt = new Date()
-  const conversationId = await db.transaction(async (tx) => {
+  const { conversationId, userMessageId } = await db.transaction(async (tx) => {
     let id = requestedId
     if (id) {
       await tx.update(conversation)
@@ -149,13 +148,31 @@ export default defineEventHandler(async (event): Promise<WidgetMessageResponse> 
         .returning({ id: conversation.id })
       id = row!.id
     }
-    await tx.insert(message).values({ conversationId: id, role: 'user', text, images })
-    return id
+    const [userMessage] = await tx.insert(message)
+      .values({ conversationId: id, role: 'user', text, images })
+      .returning({ id: message.id })
+    return { conversationId: id, userMessageId: userMessage!.id }
   })
+
+  // Published only now that the transaction has committed: an event about a
+  // rolled-back row would tell listeners of a fact that does not exist. The
+  // user message id ties together every event of this message's flow.
+  publishDomainEvent(event, createDomainEvent({
+    name: 'widget.message-received',
+    orgId,
+    userId,
+    data: {
+      conversationId,
+      messageId: userMessageId,
+      isNewConversation: !requestedId,
+      attachmentCount: images.length,
+    },
+  }))
 
   // Images are attached to the post but never sent to the model: extraction is
   // text-only for now, so a screenshot-only message is unrecognized by design.
   let parsed: WidgetAiOutput | null = null
+  let resolutionSource: 'model' | 'policy-fallback' = 'model'
   try {
     const client = new OpenAI({ apiKey, baseURL })
     const resp = await client.chat.completions.create({
@@ -180,8 +197,15 @@ export default defineEventHandler(async (event): Promise<WidgetMessageResponse> 
     const code = (err as { code?: string })?.code
     if (status === 400 && code === 'content_filter') {
       parsed = { type: 'unrecognized' }
+      resolutionSource = 'policy-fallback'
     }
     else {
+      publishDomainEvent(event, createDomainEvent({
+        name: 'widget.message-processing-failed',
+        orgId,
+        userId,
+        data: { conversationId, messageId: userMessageId, reason: 'provider-error' },
+      }))
       const detail = err instanceof Error ? err.message : 'Unknown AI error'
       throw createError({ statusCode: 502, message: `AI extraction failed: ${detail}` })
     }
@@ -189,6 +213,12 @@ export default defineEventHandler(async (event): Promise<WidgetMessageResponse> 
 
   // A malformed response is a transient model failure — the SDK may retry.
   if (!parsed) {
+    publishDomainEvent(event, createDomainEvent({
+      name: 'widget.message-processing-failed',
+      orgId,
+      userId,
+      data: { conversationId, messageId: userMessageId, reason: 'invalid-output' },
+    }))
     throw createError({ statusCode: 502, message: 'AI returned an unusable response' })
   }
   const ai = parsed
@@ -253,24 +283,21 @@ export default defineEventHandler(async (event): Promise<WidgetMessageResponse> 
     return post
   })
 
-  // Both of these read committed rows, so they follow the transaction.
+  // Published after the transaction resolves, never inside it — the assistant
+  // row (and the post, when there is one) must exist before listeners are told.
+  publishDomainEvent(event, createDomainEvent({
+    name: 'widget.message-resolved',
+    orgId,
+    userId,
+    data: { conversationId, messageId: userMessageId, outcome: ai.type, resolutionSource },
+  }))
   if (created) {
-    event.waitUntil(
-      generatePostEmbedding(created.id, orgId, created.title, content, created.contentHash),
-    )
-    if (!isActorAdmin(session, orgId)) {
-      event.waitUntil(
-        emitAdminNotification({
-          orgId,
-          typeKey: 'post.created',
-          postSlug: created.slug,
-          postTitle: created.title,
-          snippet: content,
-          actorId: userId,
-          requestOrigin: getRequestURL(event).origin,
-        }).catch((err: unknown) => console.error('[notifications] widget post created emit failed', err)),
-      )
-    }
+    publishDomainEvent(event, createDomainEvent({
+      name: 'feedback.created',
+      orgId,
+      userId,
+      data: { feedbackId: created.id, boardId: created.boardId, source: 'widget', messageId: userMessageId },
+    }))
   }
 
   return {

--- a/server/plugins/feedback-listeners.ts
+++ b/server/plugins/feedback-listeners.ts
@@ -1,0 +1,64 @@
+import { and, eq } from 'drizzle-orm'
+import { member, post } from '../db/schemas'
+
+// First in-process subscribers to feedback.created: embedding generation and
+// the staff notification. As listeners they follow every entry point that
+// publishes the event and stay off the response path. Each loads what it
+// needs by id — the event payload is deliberately minimal — and fails
+// independently: the dispatcher contains a listener error without touching
+// the other listener or the business response.
+
+async function loadFeedbackPost(feedbackId: string) {
+  const [row] = await useDB()
+    .select({
+      id: post.id,
+      slug: post.slug,
+      title: post.title,
+      content: post.content,
+      contentHash: post.contentHash,
+    })
+    .from(post)
+    .where(eq(post.id, feedbackId))
+    .limit(1)
+  return row ?? null
+}
+
+// The create endpoints read "actor is staff" off the session's org list; a
+// listener has no session, so it asks the member table — the source that org
+// list mirrors.
+async function actorIsOrgAdmin(orgId: string, userId: string): Promise<boolean> {
+  const [row] = await useDB()
+    .select({ role: member.role })
+    .from(member)
+    .where(and(eq(member.organizationId, orgId), eq(member.userId, userId)))
+    .limit(1)
+  return row?.role === 'owner' || row?.role === 'manager'
+}
+
+export default defineNitroPlugin((nitroApp) => {
+  onDomainEvent(nitroApp, 'feedback.created', async (domainEvent) => {
+    const row = await loadFeedbackPost(domainEvent.data.feedbackId)
+    // No row: deleted between commit and listener run. No hash: a legacy row
+    // this event cannot describe — every path that publishes writes one.
+    if (!row || !row.contentHash) return
+    await generatePostEmbedding(row.id, domainEvent.orgId, row.title, row.content, row.contentHash)
+  })
+
+  onDomainEvent(nitroApp, 'feedback.created', async (domainEvent, context) => {
+    // No user behind the event (system-initiated) — nobody to attribute, and
+    // staff filing feedback is routine work, not something to alert staff about.
+    if (!domainEvent.userId) return
+    if (await actorIsOrgAdmin(domainEvent.orgId, domainEvent.userId)) return
+    const row = await loadFeedbackPost(domainEvent.data.feedbackId)
+    if (!row) return
+    await emitAdminNotification({
+      orgId: domainEvent.orgId,
+      typeKey: 'post.created',
+      postSlug: row.slug,
+      postTitle: row.title,
+      snippet: row.content,
+      actorId: domainEvent.userId,
+      requestOrigin: context?.requestOrigin,
+    })
+  })
+})

--- a/server/utils/domain-events.ts
+++ b/server/utils/domain-events.ts
@@ -1,0 +1,240 @@
+import type { H3Event } from 'h3'
+import type { NitroApp } from 'nitropack/types'
+import { getRequestURL } from 'h3'
+import { uuidv7 } from 'uuidv7'
+
+// Domain events — how business code announces a fact that has already been
+// committed (a feedback post exists, a widget message was accepted) to
+// in-process subscribers: notifications, derived data such as embeddings,
+// integrations, and listeners a self-hosted deployment registers from its own
+// Nitro plugin without forking core code.
+//
+// Delivery is best-effort: listeners run outside the response lifecycle, a
+// listener failure never affects the business response, and an event can be
+// lost on process death. Anything that must not be lost needs a persistent
+// queue, not a listener here.
+//
+// Business code must publish through this facade only — never call
+// nitroApp.hooks.callHook or invent hook names. The facade is what keeps hook
+// naming, failure isolation, and scheduling in one place.
+
+// The catalog: every publishable fact and its fields. `data` stays minimal —
+// subscribers load anything else by id. The three widget message events and a
+// widget-born feedback.created share a `messageId` (the triggering user
+// message, written in the flow's first transaction) so subscribers can join
+// the events of one message flow.
+export interface FeedLogDomainEventMap {
+  'widget.message-received': {
+    conversationId: string
+    messageId: string
+    isNewConversation: boolean
+    attachmentCount: number
+  }
+  'widget.message-resolved': {
+    conversationId: string
+    messageId: string
+    outcome: 'feedback' | 'support' | 'clarify' | 'unrecognized'
+    resolutionSource: 'model' | 'policy-fallback'
+  }
+  'widget.message-processing-failed': {
+    conversationId: string
+    messageId: string
+    reason: 'provider-error' | 'invalid-output'
+  }
+  'feedback.created': {
+    feedbackId: string
+    boardId: string | null
+    // Which entry point filed the feedback — a domain fact in its own right
+    // (the post row does not record it). messageId is null for portal.
+    source: 'portal' | 'widget'
+    messageId: string | null
+  }
+}
+
+export type DomainEventName = keyof FeedLogDomainEventMap
+
+// Interfaces have no runtime form, so the catalog names are repeated here for
+// onAnyDomainEvent to register on; `satisfies` keeps the two in lockstep —
+// a map entry missing here would silently escape cross-cutting subscribers.
+const DOMAIN_EVENT_NAMES = Object.keys({
+  'widget.message-received': null,
+  'widget.message-resolved': null,
+  'widget.message-processing-failed': null,
+  'feedback.created': null,
+} satisfies Record<DomainEventName, null>) as DomainEventName[]
+
+export interface DomainEventEnvelope<Name extends DomainEventName = DomainEventName> {
+  // Unique per event, so a subscriber's own logs can be tied back to the
+  // publishing flow.
+  id: string
+  name: Name
+  // When the business fact completed — not when a listener ran.
+  occurredAt: string
+  orgId: string
+  // The acting user; null for system-initiated flows. Guests count too — they
+  // hold a real server-side user id.
+  userId: string | null
+  data: FeedLogDomainEventMap[Name]
+}
+
+// The union distributed per name, so `switch (domainEvent.name)` narrows `data`.
+export type AnyDomainEvent = {
+  [Name in DomainEventName]: DomainEventEnvelope<Name>
+}[DomainEventName]
+
+// What in-process delivery can offer beyond the envelope. Every field is
+// optional and a listener must work without any of them.
+export interface DomainEventDeliveryContext {
+  // Origin the triggering request arrived on. Carried for subscribers that
+  // build absolute links and fall back to the request origin when no canonical
+  // base URL is configured (see post-link-builder).
+  requestOrigin?: string
+  // The tenant slug the request arrived on — a readable handle for the org
+  // that orgId alone cannot give a subscriber without a lookup. Deliberately
+  // not in the envelope: a slug is a mutable label on the org, not part of
+  // the fact, and it comes from the request rather than the business flow.
+  orgSlug?: string
+  // The request that published the event, so a subscriber can read whatever
+  // else it needs — headers, cookies, locale — without this interface growing
+  // a field per use. Three constraints ride along:
+  //   - Absent whenever nothing published this from a live request, so a
+  //     subscriber that leans on it degrades silently rather than failing.
+  //   - Read it, never write to it. Listeners run after the response may have
+  //     been sent, so touching the response side throws or does nothing.
+  //   - Read it synchronously at the top of the handler. Some runtimes tear
+  //     the request down once the response completes, which is before a
+  //     listener's later awaits resume.
+  request?: H3Event
+}
+
+export type DomainEventHandler<Name extends DomainEventName = DomainEventName> = (
+  domainEvent: DomainEventEnvelope<Name>,
+  context?: DomainEventDeliveryContext,
+) => void | Promise<void>
+
+// One exact Nitro hook per fact: `feedback.created` → `feedlog:feedback:created`.
+// Narrow subscribers register on exactly the fact they care about and the
+// callback arrives already typed; there is no single shared hook and no
+// wildcard. The event name (not the hook name) is the transport-independent
+// contract other delivery paths reuse.
+export type DomainEventHookName<Name extends DomainEventName = DomainEventName> =
+  Name extends `${infer Domain}.${infer Fact}` ? `feedlog:${Domain}:${Fact}` : never
+
+type FeedLogDomainEventHooks = {
+  [Name in DomainEventName as DomainEventHookName<Name>]: DomainEventHandler<Name>
+}
+
+declare module 'nitropack/types' {
+  // Declaration merging into Nitro's hook table — the "empty" interface is the merge.
+  // eslint-disable-next-line @typescript-eslint/no-empty-object-type
+  interface NitroRuntimeHooks extends FeedLogDomainEventHooks {}
+}
+
+function toHookName(name: DomainEventName): DomainEventHookName {
+  // Event names carry exactly one dot (domain.fact), so replacing the first
+  // occurrence is replacing the only one.
+  return `feedlog:${name.replace('.', ':')}` as DomainEventHookName
+}
+
+export type DomainEventInput<Name extends DomainEventName> = Omit<
+  DomainEventEnvelope<Name>,
+  'id' | 'occurredAt'
+>
+
+// Creation is separate from publication so a caller can persist the event
+// (keeping its id) before publishing, and so occurredAt names the moment the
+// fact completed rather than the moment listeners run. Call it right after the
+// transaction that established the fact commits — never inside it, or a
+// rollback would leave listeners told of a fact that does not exist.
+export function createDomainEvent<Name extends DomainEventName>(
+  input: DomainEventInput<Name>,
+): DomainEventEnvelope<Name> {
+  return {
+    ...input,
+    id: uuidv7(),
+    occurredAt: new Date().toISOString(),
+  }
+}
+
+// Schedules listeners via event.waitUntil so they run outside the response
+// lifecycle: the response never waits for a subscriber, and the runtime still
+// keeps the process alive until listeners finish where the platform supports it.
+export function publishDomainEvent<Name extends DomainEventName>(
+  event: H3Event,
+  domainEvent: DomainEventEnvelope<Name>,
+): void {
+  const context: DomainEventDeliveryContext = {
+    requestOrigin: getRequestURL(event).origin,
+    orgSlug: event.context.orgSlug,
+    request: event,
+  }
+  event.waitUntil(dispatchDomainEvent(useNitroApp(), domainEvent, context))
+}
+
+// Hookable's callHook runs listeners sequentially and rejects on the first
+// error, which would let one subscriber starve or fail the others. Dispatch
+// therefore goes through callHookWith with allSettled: every listener runs,
+// every failure is contained. Failure logs carry only the event id, name and
+// an error summary — never the payload.
+async function dispatchDomainEvent(
+  nitroApp: NitroApp,
+  domainEvent: DomainEventEnvelope,
+  context: DomainEventDeliveryContext,
+): Promise<void> {
+  // The typed hook table pairs each hook with its exact envelope, which is
+  // right for subscribers but cannot express "this union-typed event goes to
+  // the hook derived from its own name". Erase the typing here; the pairing
+  // holds by construction.
+  const hooks = nitroApp.hooks as unknown as {
+    callHookWith: (
+      caller: (handlers: DomainEventHandler[]) => Promise<void>,
+      name: string,
+      ...args: unknown[]
+    ) => Promise<void>
+  }
+  await hooks.callHookWith(
+    async (handlers) => {
+      // The async wrapper turns a listener's synchronous throw into a
+      // rejection; bare handler(...) would escape allSettled mid-map.
+      const outcomes = await Promise.allSettled(handlers.map(async handler => handler(domainEvent, context)))
+      for (const outcome of outcomes) {
+        if (outcome.status === 'rejected') {
+          console.error(
+            `[domain-events] listener failed event=${domainEvent.id} name=${domainEvent.name}: ${errorSummary(outcome.reason)}`,
+          )
+        }
+      }
+    },
+    toHookName(domainEvent.name),
+    domainEvent,
+    context,
+  )
+}
+
+function errorSummary(reason: unknown): string {
+  return reason instanceof Error ? reason.message : String(reason)
+}
+
+// Both helpers register through nitroApp.hooks, so a listener added directly
+// via nitroApp.hooks.hook('feedlog:...') and one added here share the same
+// table and interoperate.
+export function onDomainEvent<Name extends DomainEventName>(
+  nitroApp: NitroApp,
+  name: Name,
+  handler: DomainEventHandler<Name>,
+): void {
+  // The generic name defeats Hookable's per-key callback inference; the
+  // handler's own signature already enforces the pairing.
+  nitroApp.hooks.hook(toHookName(name), handler as DomainEventHandler as never)
+}
+
+// Cross-cutting subscription: registers the handler on every catalog entry,
+// because Hookable has no wildcard and faking one would bypass typed hooks.
+export function onAnyDomainEvent(
+  nitroApp: NitroApp,
+  handler: (domainEvent: AnyDomainEvent, context?: DomainEventDeliveryContext) => void | Promise<void>,
+): void {
+  for (const name of DOMAIN_EVENT_NAMES) {
+    nitroApp.hooks.hook(toHookName(name), handler as never)
+  }
+}


### PR DESCRIPTION

## What this PR does

Add typed domain events so a committed fact is announced once and anything that follows it — notifications, embeddings, integrations
and mark stable UI actions with data-fdl-action so tooling can find them by name.


## Checklist

- [ ] Commits are signed off (`git commit -s`)
- [x] Tests pass locally (`pnpm build`)
- [x] If schema changed, migration was generated (`pnpm generate:migration`) and committed
- [x] If public API or env vars changed, `README.md` / `.env.example` / `docs/deploy/*` updated
- [x] No secrets, internal URLs, or team member names in the diff
