### PR TITLE
fix(ui): wrap text at words, not mid-character

### DIFF
--- a/app/assets/css/tailwind.css
+++ b/app/assets/css/tailwind.css
@@ -197,3 +197,25 @@
   .medium-zoom-image--opened {
     pointer-events: auto
   }
+
+/* md-editor-v3 ships `word-break: break-all` on its preview containers, which splits ordinary
+   words mid-character instead of wrapping at spaces. Restore normal word wrapping, keeping
+   `overflow-wrap` as a safety net so a genuinely unbreakable run (a long URL) still breaks
+   rather than overflowing its column.
+
+   The doubled class is deliberate. The library's CSS ships in a lazy component chunk, so
+   source order cannot decide the winner and the reset has to out-rank it on specificity. Two
+   classes also beat the theme's `div.default-theme table tr th, ... td`, which sets the legacy
+   `word-wrap` alias on cells — that rule is why `th`/`td` are listed explicitly, since it
+   overrides the value the cells would otherwise inherit from the container.
+
+   `anywhere` rather than `break-word` is load-bearing. The library renders links as
+   `display: inline-flex`, so a bare URL is a flex item, and a flex item will not shrink below
+   its min-content width. Only `anywhere` reduces min-content; under `break-word` a long link
+   keeps its full width and overflows its column instead of wrapping. */
+.md-editor-preview.md-editor-preview,
+.md-editor-html.md-editor-html,
+.md-editor-preview.md-editor-preview :is(h1, h2, h3, h4, h5, h6, th, td) {
+  word-break: normal;
+  overflow-wrap: anywhere;
+}

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -448,7 +448,7 @@ async function handleVote(post: PostListItem) {
           </div>
 
           <!-- Excerpt -->
-          <p class="text-sm text-muted-foreground line-clamp-2 break-all">
+          <p class="text-sm text-muted-foreground line-clamp-2 break-words">
             {{ p.excerpt }}
           </p>
 


### PR DESCRIPTION
## What this PR does

Stops rendered markdown wrapping mid-word. Two changes:

- **`app/assets/css/tailwind.css`** — reset the `word-break: break-all` that `md-editor-v3` applies to its preview containers, restoring normal word wrapping everywhere markdown is displayed.
- **`app/pages/index.vue`** — swap the board list excerpt's `break-all` for `break-words`.

Presentation only. No schema, API, env or dependency changes.

## Why

No issue filed — reported by a self-hosting user, reproduced against `main`.

`md-editor-v3`'s stylesheet sets `word-break: break-all` on `.md-editor-preview`, on `.md-editor-html`, and on `.md-editor-preview h1`–`h6`. `word-break` is inherited, so the whole rendered subtree picks it up and the browser may break between any two characters — even when the word would have fitted on the next line:

```
Before                              After
──────────────────────             ──────────────────────
Characteristically the             Characteristically the
internationalisati                 internationalisation
on responsibilities were           responsibilities were
uncomfortabl                       uncomfortable.
e.
```

That affects every surface that renders markdown: post bodies (`PostContent.vue`), comments (`CommentContent.vue`), the portal welcome block (`PortalWelcomeBlock.vue`), changelog entries, and the editor's `previewOnly` pane. It also silently defeats the `overflow-wrap: anywhere` that `PostContent.vue`, `CommentContent.vue` and `md-editor-preview.css` already set — that rule alone breaks only a word that genuinely cannot fit, which is the intended behaviour.

`app/pages/index.vue` had the same `break-all` applied directly to the card excerpt, producing the effect on every summary on the board list.

**The editor input is not affected** and is unchanged here. CodeMirror already wraps at word boundaries; the reported "it breaks while I type" turned out to be the preview beside it. Worth knowing if the same report reaches you.

## How to review

Three things in the reset are deliberate and would look arbitrary without explanation. All three are also written into the comment above the rule.

**1. The doubled class.** `md-editor-v3`'s CSS is imported inside `ThemedMdEditor.vue` / `ThemedMdPreview.vue`, so it ships in a lazily-loaded chunk and its order relative to the global stylesheet is not guaranteed. The reset cannot rely on coming last, so it wins on specificity instead: two classes out-rank the library's one, without `!important`.

**2. `th`/`td` are listed explicitly.** The default preview theme sets the legacy `word-wrap` alias on cells:

```css
div.default-theme table tr th, div.default-theme table tr td { word-wrap: break-word; … }
```

That overrides what cells would otherwise inherit from the container, so without naming them a table containing a long URL stops wrapping and pushes the table wider than its column.

**3. `anywhere` rather than `break-word`.** This one is easy to get wrong. The library renders links as `display: inline-flex`, so a bare URL becomes a flex item, and a flex item will not shrink below its min-content width. Only `anywhere` reduces min-content — under `break-word` a long link keeps its full width and overflows the column instead of wrapping. I had `break-word` first and it visibly regressed exactly this case.

**Deliberately not changed:** the `word-break: break-all` on the plain-text fallback link in `server/utils/email-templates.ts`, where breaking a bare URL anywhere is the point.

### Verifying it

The change was checked against a live `md-editor-v3` v6.4.2 instance rendering a document that mixes long ordinary words with unbreakable URLs in a heading, a paragraph, a list item, a table cell, a blockquote and an inline code span, in a ~300px column. Before: prose broken mid-character throughout. After: every word intact, every URL still broken (only where it cannot fit), and nothing overflowing its container in any of those contexts.

To reproduce, post a card whose body contains several long words plus a long URL in each of those constructs, then view it narrow on the board list, the post detail, a comment, a changelog entry, the welcome block, and the editor's preview toggle.

## Checklist

- [x] Commits are signed off (`git commit -s`)
- [x] Tests pass locally (`pnpm build`)
- [x] If schema changed, migration was generated and committed — n/a, no schema change
- [x] If public API or env vars changed, docs updated — n/a, presentation only
- [x] No secrets, internal URLs, or team member names in the diff
