### PR TITLE
fix(help): use pinyinlite for Cloudflare-compatible slugs

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "nuxt": "^4.3.1",
     "openai": "^6.34.0",
     "pgvector": "^0.2.1",
-    "pinyin-pro": "^3.29.3",
+    "pinyinlite": "^1.2.1",
     "postgres": "^3.4.9",
     "reka-ui": "^2.9.0",
     "shadcn-nuxt": "2.4.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,9 +83,9 @@ importers:
       pgvector:
         specifier: ^0.2.1
         version: 0.2.1
-      pinyin-pro:
-        specifier: ^3.29.3
-        version: 3.29.3
+      pinyinlite:
+        specifier: ^1.2.1
+        version: 1.2.1
       postgres:
         specifier: ^3.4.9
         version: 3.4.9
@@ -5592,8 +5592,8 @@ packages:
       typescript:
         optional: true
 
-  pinyin-pro@3.29.3:
-    resolution: {integrity: sha512-+UU9bx6vfDw8amOJGHm0TE0rdQl8VPylsDWviQ5OOQ3e+on1xRP4OqDbiDuMT5OISgvfl/Y6ez1BBRaIP80GLQ==}
+  pinyinlite@1.2.1:
+    resolution: {integrity: sha512-e3IQDbgoirNXRowOkVE5GOOWEMjugD5FX+GpQkktHpUgN4TppI3WV95CCbpsx/CtE0yLP0fHx0f/5KM4sOLrow==}
 
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
@@ -13099,7 +13099,7 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  pinyin-pro@3.29.3: {}
+  pinyinlite@1.2.1: {}
 
   pkg-types@1.3.1:
     dependencies:

--- a/server/types/pinyinlite.d.ts
+++ b/server/types/pinyinlite.d.ts
@@ -1,0 +1,6 @@
+declare module 'pinyinlite' {
+  export default function pinyin(
+    text: string,
+    options?: { keepUnrecognized?: boolean },
+  ): string[][]
+}

--- a/server/utils/help.ts
+++ b/server/utils/help.ts
@@ -1,6 +1,6 @@
 import slugify from 'slugify'
 import { customAlphabet } from 'nanoid'
-import { pinyin } from 'pinyin-pro'
+import pinyin from 'pinyinlite'
 import { and, eq, sql } from 'drizzle-orm'
 import type { SQL } from 'drizzle-orm'
 import { helpArticle, helpCollection } from '#layers/feedlog/server/db/schemas'
@@ -15,7 +15,10 @@ export function generateHelpShortId(): string {
 }
 
 export function generateHelpSlug(title: string): string {
-  const latin = pinyin(title, { toneType: 'none', nonZh: 'consecutive', type: 'string' })
+  // Keep non-Chinese runs intact so product names and version numbers stay readable.
+  const latin = pinyin(title, { keepUnrecognized: true })
+    .map(([reading], index) => reading === title[index] ? reading : ` ${reading} `)
+    .join('')
   return slugify(latin, { lower: true, strict: true }).slice(0, 80)
 }
 


### PR DESCRIPTION
## What this PR does

Keep pinyin-based help article slugs while replacing `pinyin-pro` with the lighter, Cloudflare-compatible `pinyinlite`. Preserve Latin words, numbers, and the existing 80-character slug limit.

## Why

`pinyin-pro` schedules a timer during module initialization, which prevents Cloudflare Workers deployment. `pinyinlite` uses a character dictionary without background warm-up or global API patches.

Closes #31

## How to review

The conversion is in `server/utils/help.ts`. It uses each character's first reading without contextual pronunciation matching. Existing stored slugs are not rewritten.

Validation: nine slug regression checks, targeted ESLint and TypeScript checks, Node/Cloudflare/Docker builds, and a real Cloudflare Workers deployment test.

## Checklist

- [x] Commits are signed off (`git commit -s`)
- [x] Tests pass locally (`pnpm build`)
- [x] No schema changes; no migration required
- [x] No public API or environment variable changes; no documentation changes required
- [x] No secrets, internal URLs, or team member names in the diff
