### PR TITLE
fix(build): increase the default heap limit to prevent OOM

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "private": true,
   "scripts": {
-    "build": "nuxt build && mkdir -p .output/server/db && cp -r server/db/migrations .output/server/db/migrations",
+    "build": "NODE_OPTIONS=\"--max-old-space-size=4096 $NODE_OPTIONS\" nuxt build && mkdir -p .output/server/db && cp -r server/db/migrations .output/server/db/migrations",
     "build:cf": "NITRO_PRESET=cloudflare-module pnpm build",
     "build:vercel": "pnpm migrate && NITRO_PRESET=vercel pnpm build",
     "deploy:cf": "wrangler deploy --cwd .output",


### PR DESCRIPTION
## What this PR does

Give Nuxt builds a default 4 GiB V8 old-space heap limit through the shared `build` script. Preserve existing `NODE_OPTIONS`, including user-defined heap limits.

## Why

A Cloudflare Workers build failed during Nitro bundling with `JavaScript heap out of memory` near the 2 GiB heap limit. Setting the default in the repository lets deployments build without requiring users to configure an environment variable in the dashboard. The shared script also applies to Vercel and Docker builds.

## How to review

This changes one line in `package.json` and only affects build-time Node processes. Existing options follow the default so an explicit user-provided heap limit takes precedence.

Validation: default and overridden heap limits, preservation of existing options, frozen-lockfile installation, Cloudflare and Node builds, and Docker build.

## Checklist

- [x] Commits are signed off (`git commit -s`)
- [x] Tests pass locally (`pnpm build`)
- [x] No schema or public API changes
- [x] No new environment variables or runtime configuration changes
- [x] No secrets, internal URLs, or team member names in the diff
